### PR TITLE
Add admin console and enforce role-based access control

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,602 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ascend Admin Console</title>
+    <style>
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #111;
+        color: #fff;
+        min-height: 100vh;
+      }
+
+      a {
+        color: inherit;
+      }
+
+      .hidden {
+        display: none !important;
+      }
+
+      .auth-overlay {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(0, 0, 0, 0.75);
+        padding: 1.5rem;
+        backdrop-filter: blur(2px);
+        z-index: 20;
+      }
+
+      .auth-card {
+        background: rgba(18, 18, 18, 0.95);
+        border-radius: 1rem;
+        padding: 2rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        width: min(90vw, 360px);
+        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
+      }
+
+      .auth-card h1 {
+        font-size: 1.4rem;
+        text-align: center;
+      }
+
+      .auth-field {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        font-size: 0.95rem;
+      }
+
+      .auth-field input {
+        border-radius: 999px;
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        background: rgba(0, 0, 0, 0.35);
+        color: #fff;
+        padding: 0.65rem 1rem;
+        font-size: 1rem;
+      }
+
+      .auth-submit {
+        border: none;
+        border-radius: 999px;
+        padding: 0.75rem 1rem;
+        background: #7ed957;
+        color: #111;
+        font-weight: 600;
+        font-size: 1rem;
+        cursor: pointer;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      .auth-submit:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 12px 22px rgba(126, 217, 87, 0.3);
+      }
+
+      .auth-switch {
+        font-size: 0.9rem;
+        text-align: center;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+        justify-content: center;
+        align-items: center;
+      }
+
+      .auth-switch button {
+        background: none;
+        border: none;
+        color: #7ed957;
+        font-weight: 600;
+        cursor: pointer;
+        text-decoration: underline;
+      }
+
+      .auth-error {
+        min-height: 1.25rem;
+        color: #ff7a7a;
+        text-align: center;
+        font-size: 0.85rem;
+      }
+
+      .app-header {
+        position: sticky;
+        top: 0;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+        padding: 1.25rem 1.5rem;
+        background: rgba(0, 0, 0, 0.6);
+        backdrop-filter: blur(6px);
+        border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+        z-index: 10;
+      }
+
+      .app-header nav {
+        display: flex;
+        gap: 0.75rem;
+        align-items: center;
+      }
+
+      .app-header a {
+        padding: 0.35rem 0.9rem;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.1);
+        font-size: 0.85rem;
+        font-weight: 600;
+        text-decoration: none;
+      }
+
+      .sign-out {
+        border: none;
+        border-radius: 999px;
+        padding: 0.55rem 1rem;
+        font-size: 0.9rem;
+        font-weight: 600;
+        cursor: pointer;
+        background: rgba(255, 255, 255, 0.15);
+        color: #fff;
+        transition: background 0.2s ease;
+      }
+
+      .sign-out:hover {
+        background: rgba(255, 255, 255, 0.3);
+      }
+
+      .admin-panel {
+        padding: 1.5rem;
+        max-width: 960px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+      }
+
+      .admin-panel header {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }
+
+      .admin-panel h1 {
+        font-size: 1.8rem;
+      }
+
+      .admin-panel p {
+        color: rgba(255, 255, 255, 0.75);
+      }
+
+      .status-message {
+        min-height: 1.25rem;
+        font-size: 0.9rem;
+        color: #7ed957;
+      }
+
+      .users-list {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+
+      .user-card {
+        background: rgba(18, 18, 18, 0.85);
+        border-radius: 0.85rem;
+        padding: 1rem 1.25rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+        justify-content: space-between;
+        align-items: center;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+      }
+
+      .user-details {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+      }
+
+      .user-email {
+        font-weight: 600;
+        word-break: break-word;
+      }
+
+      .role-tag {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.25rem 0.65rem;
+        border-radius: 999px;
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        background: rgba(126, 217, 87, 0.15);
+        border: 1px solid rgba(126, 217, 87, 0.35);
+        color: #a5ff80;
+        width: fit-content;
+      }
+
+      .role-tag[data-role="setter"] {
+        background: rgba(255, 222, 89, 0.15);
+        border-color: rgba(255, 222, 89, 0.35);
+        color: #ffe27a;
+      }
+
+      .role-tag[data-role="climber"] {
+        background: rgba(132, 253, 91, 0.1);
+        border-color: rgba(132, 253, 91, 0.25);
+        color: #a4ff90;
+      }
+
+      .role-tag[data-role="admin"] {
+        background: rgba(9, 24, 215, 0.25);
+        border-color: rgba(9, 24, 215, 0.45);
+        color: #9fb4ff;
+      }
+
+      .user-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+      }
+
+      .user-actions button {
+        border: none;
+        border-radius: 999px;
+        padding: 0.5rem 0.9rem;
+        font-size: 0.85rem;
+        font-weight: 600;
+        cursor: pointer;
+        color: #111;
+        transition: transform 0.15s ease, background 0.15s ease, opacity 0.15s ease;
+      }
+
+      .user-actions button:hover:not(:disabled) {
+        transform: translateY(-1px);
+      }
+
+      .user-actions button:disabled {
+        opacity: 0.45;
+        cursor: not-allowed;
+      }
+
+      .role-admin {
+        background: #809bff;
+      }
+
+      .role-setter {
+        background: #ffde59;
+      }
+
+      .role-climber {
+        background: #7ed957;
+      }
+
+      .empty-state {
+        padding: 2rem;
+        text-align: center;
+        border: 1px dashed rgba(255, 255, 255, 0.2);
+        border-radius: 0.85rem;
+        background: rgba(0, 0, 0, 0.35);
+      }
+
+      @media (max-width: 600px) {
+        .user-card {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+
+        .app-header {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+
+        .app-header nav {
+          flex-wrap: wrap;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="authOverlay" class="auth-overlay" role="dialog" aria-modal="true" aria-labelledby="authTitle">
+      <form id="authForm" class="auth-card">
+        <h1 id="authTitle">Sign in as admin</h1>
+        <label class="auth-field">
+          <span>Email</span>
+          <input id="authEmail" type="email" name="email" autocomplete="email" required />
+        </label>
+        <label class="auth-field">
+          <span>Password</span>
+          <input id="authPassword" type="password" name="password" autocomplete="current-password" minlength="6" required />
+        </label>
+        <p id="authError" class="auth-error" role="alert" aria-live="assertive"></p>
+        <button type="submit" class="auth-submit">Sign In</button>
+        <p class="auth-switch">
+          <span id="authSwitchLabel">Don't have an account?</span>
+          <button type="button" id="toggleAuthMode">Create one</button>
+        </p>
+      </form>
+    </div>
+
+    <div id="appContent" class="hidden">
+      <header class="app-header">
+        <nav>
+          <a href="index.html">Preview</a>
+          <a href="setter.html">Setter Tools</a>
+        </nav>
+        <button id="signOutButton" class="sign-out">Sign out</button>
+      </header>
+      <main class="admin-panel">
+        <header>
+          <h1>Admin Control Center</h1>
+          <p>Promote or demote users to manage who can access each Ascend page.</p>
+          <p id="statusMessage" class="status-message" role="status" aria-live="polite"></p>
+        </header>
+        <section>
+          <div id="usersContainer" class="users-list" aria-live="polite"></div>
+        </section>
+      </main>
+    </div>
+
+    <script type="module">
+      import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-app.js';
+      import { getAuth, onAuthStateChanged, signInWithEmailAndPassword, createUserWithEmailAndPassword, signOut } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-auth.js';
+      import { getFirestore, doc, getDoc, setDoc, collection, getDocs, onSnapshot, updateDoc, serverTimestamp } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js';
+
+      const firebaseConfig = {
+        apiKey: 'AIzaSyCUKr8bmjIfICZwXDHE7xoaBbAXizJhx3I',
+        authDomain: 'anuascend-3f734.firebaseapp.com',
+        projectId: 'anuascend-3f734',
+        storageBucket: 'anuascend-3f734.firebasestorage.app',
+        messagingSenderId: '305441086779',
+        appId: '1:305441086779:web:0079c53daf3462bc82eb1e',
+        measurementId: 'G-MNT686PF8L',
+      };
+
+      const firebaseApp = initializeApp(firebaseConfig);
+      const auth = getAuth(firebaseApp);
+      const db = getFirestore(firebaseApp);
+
+      const authOverlay = document.getElementById('authOverlay');
+      const appContent = document.getElementById('appContent');
+      const authForm = document.getElementById('authForm');
+      const authEmail = document.getElementById('authEmail');
+      const authPassword = document.getElementById('authPassword');
+      const authError = document.getElementById('authError');
+      const authTitle = document.getElementById('authTitle');
+      const authSwitchLabel = document.getElementById('authSwitchLabel');
+      const toggleAuthModeButton = document.getElementById('toggleAuthMode');
+      const signOutButton = document.getElementById('signOutButton');
+      const usersContainer = document.getElementById('usersContainer');
+      const statusMessage = document.getElementById('statusMessage');
+
+      let authMode = 'login';
+      let unsubscribeUsers = null;
+
+      function setAuthMode(mode) {
+        authMode = mode;
+        const isLogin = authMode === 'login';
+        authTitle.textContent = isLogin ? 'Sign in as admin' : 'Create an admin account';
+        authSwitchLabel.textContent = isLogin ? "Don't have an account?" : 'Already have an account?';
+        toggleAuthModeButton.textContent = isLogin ? 'Create one' : 'Sign in';
+        authForm.querySelector('.auth-submit').textContent = isLogin ? 'Sign In' : 'Create Account';
+        authPassword.setAttribute('autocomplete', isLogin ? 'current-password' : 'new-password');
+        authError.textContent = '';
+      }
+
+      toggleAuthModeButton.addEventListener('click', () => {
+        setAuthMode(authMode === 'login' ? 'register' : 'login');
+      });
+
+      authForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        authError.textContent = '';
+        const email = authEmail.value.trim();
+        const password = authPassword.value;
+
+        try {
+          if (authMode === 'login') {
+            await signInWithEmailAndPassword(auth, email, password);
+          } else {
+            const userCredential = await createUserWithEmailAndPassword(auth, email, password);
+            await ensureUserRole(userCredential.user);
+          }
+        } catch (error) {
+          authError.textContent = error.message;
+        }
+      });
+
+      signOutButton.addEventListener('click', () => {
+        stopUsersListener();
+        signOut(auth).catch((error) => {
+          console.error('Failed to sign out:', error);
+        });
+      });
+
+      async function ensureUserRole(user) {
+        if (!user) {
+          return 'climber';
+        }
+
+        const userDocRef = doc(db, 'userRoles', user.uid);
+        const existingSnapshot = await getDoc(userDocRef);
+
+        if (existingSnapshot.exists()) {
+          const existingData = existingSnapshot.data();
+          if (!existingData.email && user.email) {
+            await setDoc(userDocRef, { email: user.email }, { merge: true });
+          }
+          return existingData.role ?? 'climber';
+        }
+
+        const rolesSnapshot = await getDocs(collection(db, 'userRoles'));
+        const assignedRole = rolesSnapshot.empty ? 'admin' : 'climber';
+
+        await setDoc(userDocRef, {
+          role: assignedRole,
+          email: user.email ?? '',
+          createdAt: serverTimestamp(),
+        });
+
+        return assignedRole;
+      }
+
+      function renderUsers(users) {
+        usersContainer.innerHTML = '';
+
+        if (!users.length) {
+          const emptyState = document.createElement('div');
+          emptyState.className = 'empty-state';
+          emptyState.textContent = 'No users found yet.';
+          usersContainer.appendChild(emptyState);
+          return;
+        }
+
+        const sortedUsers = [...users].sort((a, b) => (a.email || '').localeCompare(b.email || ''));
+
+        sortedUsers.forEach((userEntry) => {
+            const card = document.createElement('div');
+            card.className = 'user-card';
+
+            const details = document.createElement('div');
+            details.className = 'user-details';
+
+            const emailLabel = document.createElement('span');
+            emailLabel.className = 'user-email';
+            emailLabel.textContent = userEntry.email || 'Unknown email';
+
+            const roleTag = document.createElement('span');
+            roleTag.className = 'role-tag';
+            roleTag.dataset.role = userEntry.role;
+            roleTag.textContent = userEntry.role;
+
+            details.appendChild(emailLabel);
+            details.appendChild(roleTag);
+
+            if (auth.currentUser && auth.currentUser.uid === userEntry.id) {
+              const youTag = document.createElement('span');
+              youTag.textContent = 'This is you';
+              youTag.style.fontSize = '0.75rem';
+              youTag.style.opacity = '0.7';
+              details.appendChild(youTag);
+            }
+
+            const actions = document.createElement('div');
+            actions.className = 'user-actions';
+
+            const roleOptions = [
+              { role: 'admin', label: 'Make Admin', className: 'role-admin' },
+              { role: 'setter', label: 'Make Setter', className: 'role-setter' },
+              { role: 'climber', label: 'Make Climber', className: 'role-climber' },
+            ];
+
+            const isCurrentUser = auth.currentUser && auth.currentUser.uid === userEntry.id;
+
+            roleOptions.forEach((option) => {
+              const button = document.createElement('button');
+              button.className = option.className;
+              button.type = 'button';
+              button.textContent = option.label;
+              button.disabled = userEntry.role === option.role;
+              button.addEventListener('click', () => {
+                if (isCurrentUser && option.role !== 'admin') {
+                  const confirmed = window.confirm(
+                    'You are about to change your own role. You may lose access to this page. Continue?'
+                  );
+                  if (!confirmed) {
+                    return;
+                  }
+                }
+                updateUserRole(userEntry.id, option.role, userEntry.email);
+              });
+              actions.appendChild(button);
+            });
+
+            card.appendChild(details);
+            card.appendChild(actions);
+            usersContainer.appendChild(card);
+          });
+      }
+
+      async function updateUserRole(userId, newRole, email) {
+        statusMessage.style.color = '#7ed957';
+        statusMessage.textContent = `Updating ${email || 'user'} to ${newRole}...`;
+        try {
+          await updateDoc(doc(db, 'userRoles', userId), {
+            role: newRole,
+            updatedAt: serverTimestamp(),
+          });
+          statusMessage.textContent = `Updated ${email || 'user'} to ${newRole}.`;
+        } catch (error) {
+          console.error('Failed to update user role:', error);
+          statusMessage.style.color = '#ff7a7a';
+          statusMessage.textContent = 'Failed to update user role. Please try again.';
+        }
+      }
+
+      function stopUsersListener() {
+        if (unsubscribeUsers) {
+          unsubscribeUsers();
+          unsubscribeUsers = null;
+        }
+      }
+
+      onAuthStateChanged(auth, async (user) => {
+        if (user) {
+          try {
+            const role = await ensureUserRole(user);
+
+            if (role !== 'admin') {
+              alert('You must be an admin to access this page.');
+              stopUsersListener();
+              window.location.href = 'index.html';
+              return;
+            }
+
+            authOverlay.classList.add('hidden');
+            appContent.classList.remove('hidden');
+
+            if (!unsubscribeUsers) {
+              unsubscribeUsers = onSnapshot(collection(db, 'userRoles'), (snapshot) => {
+                const users = snapshot.docs.map((docSnapshot) => ({
+                  id: docSnapshot.id,
+                  ...docSnapshot.data(),
+                }));
+                renderUsers(users);
+              });
+            }
+          } catch (error) {
+            console.error('Failed to verify user role:', error);
+            authError.textContent = 'Unable to verify account role. Please try again.';
+          }
+        } else {
+          stopUsersListener();
+          usersContainer.innerHTML = '';
+          statusMessage.style.color = '#7ed957';
+          statusMessage.textContent = '';
+          authOverlay.classList.remove('hidden');
+          appContent.classList.add('hidden');
+          authForm.reset();
+          setAuthMode('login');
+        }
+      });
+
+      setAuthMode('login');
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -169,6 +169,7 @@
     <script type="module">
       import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-app.js';
       import { getAuth, onAuthStateChanged, signInWithEmailAndPassword, createUserWithEmailAndPassword, signOut } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-auth.js';
+      import { getFirestore, doc, getDoc, setDoc, collection, getDocs, serverTimestamp } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js';
 
       const firebaseConfig = {
         apiKey: 'AIzaSyCUKr8bmjIfICZwXDHE7xoaBbAXizJhx3I',
@@ -182,6 +183,7 @@
 
       const firebaseApp = initializeApp(firebaseConfig);
       const auth = getAuth(firebaseApp);
+      const db = getFirestore(firebaseApp);
 
       const authOverlay = document.getElementById('authOverlay');
       const appContent = document.getElementById('appContent');
@@ -221,7 +223,8 @@
           if (authMode === 'login') {
             await signInWithEmailAndPassword(auth, email, password);
           } else {
-            await createUserWithEmailAndPassword(auth, email, password);
+            const userCredential = await createUserWithEmailAndPassword(auth, email, password);
+            await ensureUserRole(userCredential.user);
           }
         } catch (error) {
           authError.textContent = error.message;
@@ -234,10 +237,44 @@
         });
       });
 
-      onAuthStateChanged(auth, (user) => {
+      async function ensureUserRole(user) {
+        if (!user) {
+          return 'climber';
+        }
+
+        const userDocRef = doc(db, 'userRoles', user.uid);
+        const existingSnapshot = await getDoc(userDocRef);
+
+        if (existingSnapshot.exists()) {
+          const existingData = existingSnapshot.data();
+          if (!existingData.email && user.email) {
+            await setDoc(userDocRef, { email: user.email }, { merge: true });
+          }
+          return existingData.role ?? 'climber';
+        }
+
+        const rolesSnapshot = await getDocs(collection(db, 'userRoles'));
+        const assignedRole = rolesSnapshot.empty ? 'admin' : 'climber';
+
+        await setDoc(userDocRef, {
+          role: assignedRole,
+          email: user.email ?? '',
+          createdAt: serverTimestamp(),
+        });
+
+        return assignedRole;
+      }
+
+      onAuthStateChanged(auth, async (user) => {
         if (user) {
-          authOverlay.classList.add('hidden');
-          appContent.classList.remove('hidden');
+          try {
+            await ensureUserRole(user);
+            authOverlay.classList.add('hidden');
+            appContent.classList.remove('hidden');
+          } catch (error) {
+            console.error('Failed to verify user role:', error);
+            authError.textContent = 'Unable to verify account role. Please try again.';
+          }
         } else {
           authOverlay.classList.remove('hidden');
           appContent.classList.add('hidden');

--- a/setter.html
+++ b/setter.html
@@ -285,6 +285,7 @@
   <script type="module">
     import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-app.js';
     import { getAuth, onAuthStateChanged, signInWithEmailAndPassword, createUserWithEmailAndPassword, signOut } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-auth.js';
+    import { getFirestore, doc, getDoc, setDoc, collection, getDocs, serverTimestamp } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js';
 
     const firebaseConfig = {
       apiKey: 'AIzaSyCUKr8bmjIfICZwXDHE7xoaBbAXizJhx3I',
@@ -298,6 +299,7 @@
 
     const firebaseApp = initializeApp(firebaseConfig);
     const auth = getAuth(firebaseApp);
+    const db = getFirestore(firebaseApp);
 
     const authOverlay = document.getElementById('authOverlay');
     const appContent = document.getElementById('appContent');
@@ -337,7 +339,8 @@
         if (authMode === 'login') {
           await signInWithEmailAndPassword(auth, email, password);
         } else {
-          await createUserWithEmailAndPassword(auth, email, password);
+          const userCredential = await createUserWithEmailAndPassword(auth, email, password);
+          await ensureUserRole(userCredential.user);
         }
       } catch (error) {
         authError.textContent = error.message;
@@ -350,10 +353,50 @@
       });
     });
 
-    onAuthStateChanged(auth, (user) => {
+    async function ensureUserRole(user) {
+      if (!user) {
+        return 'climber';
+      }
+
+      const userDocRef = doc(db, 'userRoles', user.uid);
+      const existingSnapshot = await getDoc(userDocRef);
+
+      if (existingSnapshot.exists()) {
+        const existingData = existingSnapshot.data();
+        if (!existingData.email && user.email) {
+          await setDoc(userDocRef, { email: user.email }, { merge: true });
+        }
+        return existingData.role ?? 'climber';
+      }
+
+      const rolesSnapshot = await getDocs(collection(db, 'userRoles'));
+      const assignedRole = rolesSnapshot.empty ? 'admin' : 'climber';
+
+      await setDoc(userDocRef, {
+        role: assignedRole,
+        email: user.email ?? '',
+        createdAt: serverTimestamp(),
+      });
+
+      return assignedRole;
+    }
+
+    onAuthStateChanged(auth, async (user) => {
       if (user) {
-        authOverlay.classList.add('hidden');
-        appContent.classList.remove('hidden');
+        try {
+          const role = await ensureUserRole(user);
+
+          if (role === 'admin' || role === 'setter') {
+            authOverlay.classList.add('hidden');
+            appContent.classList.remove('hidden');
+          } else {
+            alert('You do not have permission to access the setter tools.');
+            window.location.href = 'index.html';
+          }
+        } catch (error) {
+          console.error('Failed to verify user role:', error);
+          authError.textContent = 'Unable to verify account role. Please try again.';
+        }
       } else {
         authOverlay.classList.remove('hidden');
         appContent.classList.add('hidden');


### PR DESCRIPTION
## Summary
- add a dedicated admin console that lists users, highlights their roles, and lets admins promote or demote accounts via Firestore
- ensure newly registered users receive a stored role with the first user promoted to admin and display role-aware authentication flows
- gate the setter tools behind admin/setter roles while keeping the index page role-aware for consistent access control

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e516f4ef048327a468c89f341c0f18