### PR TITLE
Enable Firestore route management across setter and preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,6 +170,38 @@
       .sign-out:hover {
         background: rgba(255, 255, 255, 0.3);
       }
+
+      .route-tooltip {
+        position: fixed;
+        pointer-events: none;
+        background: rgba(0, 0, 0, 0.75);
+        color: #fff;
+        padding: 0.75rem 1rem;
+        border-radius: 0.75rem;
+        box-shadow: 0 12px 30px rgba(0, 0, 0, 0.45);
+        font-size: 0.85rem;
+        line-height: 1.4;
+        max-width: min(280px, 80vw);
+        z-index: 6;
+        opacity: 0;
+        transform: translate(-50%, -12px);
+        transition: opacity 0.12s ease, transform 0.12s ease;
+      }
+
+      .route-tooltip.visible {
+        opacity: 1;
+        transform: translate(-50%, 0);
+      }
+
+      .route-tooltip strong {
+        display: block;
+        font-size: 0.95rem;
+        margin-bottom: 0.35rem;
+      }
+
+      .route-tooltip span + span {
+        margin-top: 0.25rem;
+      }
     </style>
   </head>
   <body>
@@ -202,6 +234,13 @@
       </header>
       <canvas id="previewCanvas" aria-hidden="true"></canvas>
     </div>
+    <div
+      id="routeTooltip"
+      class="route-tooltip"
+      role="status"
+      aria-live="polite"
+      aria-hidden="true"
+    ></div>
     <script type="module">
       import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-app.js';
       import {
@@ -250,6 +289,7 @@
       const signOutButton = document.getElementById('signOutButton');
       const roleBadge = document.getElementById('roleBadge');
       const setterLink = document.getElementById('setterLink');
+      const tooltip = document.getElementById('routeTooltip');
 
       let authMode = 'login';
 
@@ -385,6 +425,122 @@
       const ctx = canvas.getContext('2d');
 
       let routes = [];
+      let routePaths = [];
+      let activeRouteId = null;
+
+      function normalizeDate(value) {
+        if (!value) {
+          return null;
+        }
+
+        if (typeof value === 'string') {
+          const date = new Date(value);
+          return Number.isNaN(date.getTime()) ? null : date.toISOString();
+        }
+
+        if (value instanceof Date) {
+          return Number.isNaN(value.getTime()) ? null : value.toISOString();
+        }
+
+        if (typeof value?.toDate === 'function') {
+          const date = value.toDate();
+          if (date instanceof Date && !Number.isNaN(date.getTime())) {
+            return date.toISOString();
+          }
+          return null;
+        }
+
+        return null;
+      }
+
+      function formatDisplayDate(isoString) {
+        if (!isoString) {
+          return 'Unknown';
+        }
+
+        const date = new Date(isoString);
+        if (Number.isNaN(date.getTime())) {
+          return 'Unknown';
+        }
+
+        return date.toLocaleDateString(undefined, {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+        });
+      }
+
+      function updateTooltipContent(route) {
+        if (!tooltip) {
+          return;
+        }
+
+        tooltip.innerHTML = '';
+
+        const titleLine = document.createElement('strong');
+        titleLine.textContent = route.title || route.id;
+        tooltip.appendChild(titleLine);
+
+        const setterLine = document.createElement('span');
+        setterLine.textContent = `Setter: ${route.setter || 'Unknown'}`;
+        tooltip.appendChild(setterLine);
+
+        const descriptionLine = document.createElement('span');
+        descriptionLine.textContent = route.description ? `Description: ${route.description}` : 'Description: —';
+        tooltip.appendChild(descriptionLine);
+
+        const dateLine = document.createElement('span');
+        dateLine.textContent = `Date set: ${formatDisplayDate(route.date_set)}`;
+        tooltip.appendChild(dateLine);
+      }
+
+      function positionTooltip(clientX, clientY) {
+        if (!tooltip) {
+          return;
+        }
+
+        const tooltipWidth = tooltip.offsetWidth || 0;
+        const tooltipHeight = tooltip.offsetHeight || 0;
+        const halfWidth = tooltipWidth / 2;
+
+        const minX = halfWidth + 12;
+        const maxX = window.innerWidth - halfWidth - 12;
+        const desiredLeft = clientX;
+        const clampedLeft = maxX < minX ? window.innerWidth / 2 : Math.min(maxX, Math.max(minX, desiredLeft));
+
+        const minTop = 20;
+        const maxTop = window.innerHeight - tooltipHeight + 4;
+        const desiredTop = clientY - 24;
+        const clampedTop = maxTop < minTop ? window.innerHeight / 2 : Math.min(maxTop, Math.max(minTop, desiredTop));
+
+        tooltip.style.left = `${clampedLeft}px`;
+        tooltip.style.top = `${clampedTop}px`;
+      }
+
+      function showTooltip(route, clientX, clientY) {
+        if (!tooltip) {
+          return;
+        }
+
+        if (route.id !== activeRouteId) {
+          updateTooltipContent(route);
+        }
+
+        positionTooltip(clientX, clientY);
+        tooltip.classList.add('visible');
+        tooltip.setAttribute('aria-hidden', 'false');
+        activeRouteId = route.id;
+      }
+
+      function hideTooltip() {
+        if (!tooltip) {
+          return;
+        }
+
+        tooltip.classList.remove('visible');
+        tooltip.setAttribute('aria-hidden', 'true');
+        activeRouteId = null;
+      }
 
       async function loadRoutes() {
         try {
@@ -409,13 +565,16 @@
                 id: docSnap.id,
                 strokeColor: typeof data.strokeColor === 'string' ? data.strokeColor : '#ffde59',
                 points: normalizedPoints,
-                name: data.name ?? '',
-                grade: data.grade ?? '',
+                title: typeof data.title === 'string' ? data.title : '',
+                setter: typeof data.setter === 'string' ? data.setter : '',
+                description: typeof data.description === 'string' ? data.description : '',
+                date_set: normalizeDate(data.date_set),
+                date_removed: normalizeDate(data.date_removed),
               };
             })
             .sort((a, b) => {
-              const nameA = (a.name || a.id).toLowerCase();
-              const nameB = (b.name || b.id).toLowerCase();
+              const nameA = (a.title || a.id).toLowerCase();
+              const nameB = (b.title || b.id).toLowerCase();
               return nameA.localeCompare(nameB);
             });
 
@@ -452,6 +611,8 @@
           ctx.fillRect(0, 0, canvas.width, canvas.height);
         }
 
+        routePaths = [];
+        hideTooltip();
         routes.forEach(drawRoute);
       }
 
@@ -462,12 +623,6 @@
         if (points.length < 2) {
           return;
         }
-
-        ctx.lineWidth = 10;
-        ctx.strokeStyle = strokeColor;
-        ctx.lineJoin = 'round';
-        ctx.lineCap = 'round';
-        ctx.beginPath();
 
         const scaledPoints = points
           .map((point) => {
@@ -487,7 +642,8 @@
           return;
         }
 
-        ctx.moveTo(scaledPoints[0].x, scaledPoints[0].y);
+        const path = new Path2D();
+        path.moveTo(scaledPoints[0].x, scaledPoints[0].y);
 
         for (let i = 0; i < scaledPoints.length - 1; i++) {
           const p0 = i === 0 ? scaledPoints[0] : scaledPoints[i - 1];
@@ -500,10 +656,60 @@
           const cp2x = p2.x - (p3.x - p1.x) / 6;
           const cp2y = p2.y - (p3.y - p1.y) / 6;
 
-          ctx.bezierCurveTo(cp1x, cp1y, cp2x, cp2y, p2.x, p2.y);
+          path.bezierCurveTo(cp1x, cp1y, cp2x, cp2y, p2.x, p2.y);
         }
 
-        ctx.stroke();
+        const lineWidth = 10;
+        ctx.lineWidth = lineWidth;
+        ctx.strokeStyle = strokeColor;
+        ctx.lineJoin = 'round';
+        ctx.lineCap = 'round';
+        ctx.stroke(path);
+
+        routePaths.push({
+          route,
+          path,
+          lineWidth,
+        });
+      }
+
+      function handlePointerMove(event) {
+        if ('pointerType' in event && event.pointerType !== 'mouse') {
+          hideTooltip();
+          return;
+        }
+
+        if (!routePaths.length) {
+          hideTooltip();
+          return;
+        }
+
+        const rect = canvas.getBoundingClientRect();
+        const x = event.clientX - rect.left;
+        const y = event.clientY - rect.top;
+
+        for (let index = routePaths.length - 1; index >= 0; index -= 1) {
+          const entry = routePaths[index];
+          const previousLineWidth = ctx.lineWidth;
+          ctx.lineWidth = entry.lineWidth;
+          const isInside = ctx.isPointInStroke(entry.path, x, y);
+          ctx.lineWidth = previousLineWidth;
+
+          if (isInside) {
+            showTooltip(entry.route, event.clientX, event.clientY);
+            return;
+          }
+        }
+
+        hideTooltip();
+      }
+
+      if ('PointerEvent' in window) {
+        canvas.addEventListener('pointermove', handlePointerMove);
+        canvas.addEventListener('pointerleave', hideTooltip);
+      } else {
+        canvas.addEventListener('mousemove', handlePointerMove);
+        canvas.addEventListener('mouseleave', hideTooltip);
       }
 
       window.addEventListener('resize', resizeCanvas);

--- a/setter.html
+++ b/setter.html
@@ -64,13 +64,19 @@
     }
 
     .control-field input,
-    .control-field select {
+    .control-field select,
+    .control-field textarea {
       border-radius: 0.65rem;
       border: 1px solid rgba(255, 255, 255, 0.15);
       background: rgba(0, 0, 0, 0.35);
       color: inherit;
       padding: 0.5rem 0.75rem;
       font-size: 0.9rem;
+    }
+
+    .control-field textarea {
+      min-height: 4.5rem;
+      resize: vertical;
     }
 
     .control-row {
@@ -360,13 +366,27 @@
           <button id="newRouteButton" type="button">New</button>
         </div>
         <label class="control-field">
-          <span>Name</span>
-          <input id="routeNameInput" type="text" placeholder="Route name" autocomplete="off" />
+          <span>Setter</span>
+          <input id="routeSetterInput" type="email" placeholder="setter@example.com" autocomplete="off" />
         </label>
         <label class="control-field">
-          <span>Grade</span>
-          <input id="routeGradeInput" type="text" placeholder="Grade" autocomplete="off" />
+          <span>Title</span>
+          <input id="routeTitleInput" type="text" placeholder="Route title" autocomplete="off" />
         </label>
+        <label class="control-field">
+          <span>Description</span>
+          <textarea id="routeDescriptionInput" placeholder="Describe the climb"></textarea>
+        </label>
+        <div class="control-row">
+          <label class="control-field">
+            <span>Date set</span>
+            <input id="routeDateSetInput" type="datetime-local" />
+          </label>
+          <label class="control-field">
+            <span>Date removed (optional)</span>
+            <input id="routeDateRemovedInput" type="datetime-local" />
+          </label>
+        </div>
       </div>
       <div class="control-section">
         <label class="control-field">
@@ -440,8 +460,11 @@
     const roleBadge = document.getElementById('roleBadge');
     const routeSelector = document.getElementById('routeSelector');
     const routeIdInput = document.getElementById('routeIdInput');
-    const routeNameInput = document.getElementById('routeNameInput');
-    const routeGradeInput = document.getElementById('routeGradeInput');
+    const routeSetterInput = document.getElementById('routeSetterInput');
+    const routeTitleInput = document.getElementById('routeTitleInput');
+    const routeDescriptionInput = document.getElementById('routeDescriptionInput');
+    const routeDateSetInput = document.getElementById('routeDateSetInput');
+    const routeDateRemovedInput = document.getElementById('routeDateRemovedInput');
     const newRouteButton = document.getElementById('newRouteButton');
     const deleteButton = document.getElementById('deleteButton');
     const routeStatus = document.getElementById('routeStatus');
@@ -462,8 +485,82 @@
     let currentRouteId = '';
     let hasUnsavedChanges = false;
     let isSaving = false;
+    let currentUserEmail = '';
 
     const routesCache = new Map();
+
+    function normalizeDateValue(value) {
+      if (!value) {
+        return null;
+      }
+
+      if (typeof value === 'string') {
+        const date = new Date(value);
+        return Number.isNaN(date.getTime()) ? null : date.toISOString();
+      }
+
+      if (value instanceof Date) {
+        return Number.isNaN(value.getTime()) ? null : value.toISOString();
+      }
+
+      if (typeof value?.toDate === 'function') {
+        const date = value.toDate();
+        if (date instanceof Date && !Number.isNaN(date.getTime())) {
+          return date.toISOString();
+        }
+        return null;
+      }
+
+      return null;
+    }
+
+    function isoStringToInputValue(isoString) {
+      if (!isoString) {
+        return '';
+      }
+
+      const date = new Date(isoString);
+      if (Number.isNaN(date.getTime())) {
+        return '';
+      }
+
+      const offset = date.getTimezoneOffset();
+      const local = new Date(date.getTime() - offset * 60000);
+      return local.toISOString().slice(0, 16);
+    }
+
+    function inputValueToIsoString(inputValue) {
+      if (!inputValue) {
+        return null;
+      }
+
+      const date = new Date(inputValue);
+      if (Number.isNaN(date.getTime())) {
+        return null;
+      }
+
+      return date.toISOString();
+    }
+
+    function getNowInputValue() {
+      const now = new Date();
+      const offset = now.getTimezoneOffset();
+      const local = new Date(now.getTime() - offset * 60000);
+      return local.toISOString().slice(0, 16);
+    }
+
+    function normalizeRouteData(raw = {}) {
+      return {
+        ...raw,
+        setter: typeof raw.setter === 'string' ? raw.setter : '',
+        title: typeof raw.title === 'string' ? raw.title : '',
+        description: typeof raw.description === 'string' ? raw.description : '',
+        strokeColor: sanitizeColor(raw.strokeColor),
+        points: Array.isArray(raw.points) ? raw.points : [],
+        date_set: normalizeDateValue(raw.date_set),
+        date_removed: normalizeDateValue(raw.date_removed),
+      };
+    }
 
     function setStatus(message, variant = 'info') {
       if (!routeStatus) {
@@ -647,19 +744,26 @@
       return '#ffde59';
     }
 
-    function applyRouteToCanvas(routeId, data = {}) {
+    function applyRouteToCanvas(routeId, rawData = {}) {
+      const data = normalizeRouteData(rawData);
+
       currentRouteId = routeId;
       routeSelector.value = routeId;
       routeIdInput.value = routeId;
-      routeNameInput.value = data.name ?? '';
-      routeGradeInput.value = data.grade ?? '';
-      strokeColor = sanitizeColor(data.strokeColor);
+      routeSetterInput.value = data.setter || currentUserEmail || '';
+      routeTitleInput.value = data.title;
+      routeDescriptionInput.value = data.description;
+      routeDateSetInput.value = isoStringToInputValue(data.date_set) || '';
+      routeDateRemovedInput.value = isoStringToInputValue(data.date_removed) || '';
+      strokeColor = data.strokeColor;
       colorPicker.value = strokeColor;
-      applyNormalizedPoints(Array.isArray(data.points) ? data.points : []);
+      applyNormalizedPoints(data.points);
       deleteButton.disabled = !routeId;
       resetUnsavedState();
+
       if (routeId) {
-        const label = data.name ? `${data.name} (${routeId})` : routeId;
+        routesCache.set(routeId, data);
+        const label = data.title ? `${data.title} (${routeId})` : routeId;
         setStatus(`Loaded route ${label}.`, 'success');
       }
     }
@@ -668,8 +772,13 @@
       currentRouteId = '';
       routeSelector.value = '';
       routeIdInput.value = '';
-      routeNameInput.value = '';
-      routeGradeInput.value = '';
+      routeSetterInput.value = currentUserEmail || '';
+      routeTitleInput.value = '';
+      routeDescriptionInput.value = '';
+      routeDateSetInput.value = getNowInputValue();
+      routeDateRemovedInput.value = '';
+      strokeColor = '#ffde59';
+      colorPicker.value = strokeColor;
       loadedNormalizedPoints = null;
       points.length = 0;
       redraw();
@@ -688,12 +797,12 @@
         const snapshot = await getDocs(collection(db, 'routes'));
         routesCache.clear();
         snapshot.forEach((docSnap) => {
-          routesCache.set(docSnap.id, docSnap.data());
+          routesCache.set(docSnap.id, normalizeRouteData(docSnap.data()));
         });
 
         const sortedEntries = [...routesCache.entries()].sort((a, b) => {
-          const labelA = (a[1]?.name || a[0]).toLowerCase();
-          const labelB = (b[1]?.name || b[0]).toLowerCase();
+          const labelA = (a[1]?.title || a[0]).toLowerCase();
+          const labelB = (b[1]?.title || b[0]).toLowerCase();
           return labelA.localeCompare(labelB);
         });
 
@@ -706,7 +815,7 @@
         sortedEntries.forEach(([id, data]) => {
           const option = document.createElement('option');
           option.value = id;
-          option.textContent = data?.name ? `${data.name} (${id})` : id;
+          option.textContent = data?.title ? `${data.title} (${id})` : id;
           routeSelector.appendChild(option);
         });
 
@@ -740,14 +849,46 @@
       }
 
       const normalizedPoints = convertPointsToNormalized();
-      const name = routeNameInput.value.trim();
-      const grade = routeGradeInput.value.trim();
+      const setter = routeSetterInput.value.trim();
+      routeSetterInput.value = setter;
+      if (!setter) {
+        setStatus('Setter email is required before saving.', 'error');
+        routeSetterInput.focus();
+        return;
+      }
+
+      const title = routeTitleInput.value.trim();
+      routeTitleInput.value = title;
+      if (!title) {
+        setStatus('Route title is required before saving.', 'error');
+        routeTitleInput.focus();
+        return;
+      }
+
+      const description = routeDescriptionInput.value.trim();
+      routeDescriptionInput.value = description;
+      const dateSetIso = inputValueToIsoString(routeDateSetInput.value);
+      if (!dateSetIso) {
+        setStatus('Enter a valid set date for the route.', 'error');
+        routeDateSetInput.focus();
+        return;
+      }
+
+      const dateRemovedIso = inputValueToIsoString(routeDateRemovedInput.value);
+      if (routeDateRemovedInput.value && !dateRemovedIso) {
+        setStatus('Enter a valid removal date or clear the field.', 'error');
+        routeDateRemovedInput.focus();
+        return;
+      }
 
       const payload = {
-        name: name || null,
-        grade: grade || null,
+        setter,
+        title,
+        description: description || null,
         strokeColor,
         points: normalizedPoints,
+        date_set: dateSetIso,
+        date_removed: dateRemovedIso ?? null,
         updatedAt: serverTimestamp(),
       };
 
@@ -769,13 +910,16 @@
 
         loadedNormalizedPoints = normalizedPoints;
         currentRouteId = routeId;
+        routesCache.set(routeId, normalizeRouteData(payload));
         resetUnsavedState();
 
         await loadRoutesList(routeId);
         routeSelector.value = routeId;
+        routeIdInput.value = routeId;
         deleteButton.disabled = false;
 
-        setStatus(`Route “${routeId}” saved successfully.`, 'success');
+        const label = title || routeId;
+        setStatus(`Route “${label}” saved successfully.`, 'success');
       } catch (error) {
         console.error('Failed to save route:', error);
         setStatus(error.message || 'Failed to save route.', 'error');
@@ -794,7 +938,9 @@
         return;
       }
 
-      const confirmed = window.confirm(`Delete route “${targetId}”? This cannot be undone.`);
+      const cachedRoute = routesCache.get(targetId);
+      const routeLabel = cachedRoute?.title ? `${cachedRoute.title} (${targetId})` : targetId;
+      const confirmed = window.confirm(`Delete route “${routeLabel}”? This cannot be undone.`);
       if (!confirmed) {
         return;
       }
@@ -810,7 +956,7 @@
 
         await loadRoutesList();
         prepareNewRoute('Route deleted. You can create a new one.');
-        setStatus(`Route “${targetId}” deleted.`, 'success');
+        setStatus(`Route “${routeLabel}” deleted.`, 'success');
       } catch (error) {
         console.error('Failed to delete route:', error);
         setStatus(error.message || 'Failed to delete route.', 'error');
@@ -820,6 +966,19 @@
         routeSelector.disabled = false;
       }
     }
+
+    [routeIdInput, routeSetterInput, routeTitleInput, routeDescriptionInput].forEach((element) => {
+      if (element) {
+        element.addEventListener('input', markUnsavedChange);
+      }
+    });
+
+    [routeDateSetInput, routeDateRemovedInput].forEach((element) => {
+      if (element) {
+        element.addEventListener('change', markUnsavedChange);
+        element.addEventListener('input', markUnsavedChange);
+      }
+    });
 
     canvas.addEventListener('click', addPoint);
     window.addEventListener('resize', resizeCanvas);
@@ -843,7 +1002,7 @@
         try {
           const snap = await getDoc(doc(db, 'routes', selectedId));
           if (snap.exists()) {
-            data = snap.data();
+            data = normalizeRouteData(snap.data());
             routesCache.set(selectedId, data);
           }
         } catch (error) {
@@ -993,6 +1152,7 @@
 
     onAuthStateChanged(auth, async (user) => {
       if (user) {
+        currentUserEmail = user.email ?? '';
         authOverlay.classList.add('hidden');
 
         const role = await resolveUserRole(user);
@@ -1021,6 +1181,7 @@
           console.error('Unable to initialise routes:', error);
         }
       } else {
+        currentUserEmail = '';
         authOverlay.classList.remove('hidden');
         appContent.classList.add('hidden');
         unauthorizedNotice.classList.add('hidden');


### PR DESCRIPTION
## Summary
- replace the setter JSON modal with controls to create, update, and delete routes in Firestore
- populate the setter controls and preview canvas from the `/routes/{routeId}` documents
- surface route status messaging and synchronized canvas rendering for stored climbs

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e52a1ac6208327889289e27e163105