### PR TITLE
Delete ascended doc when route unmarked

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,6 +306,7 @@
         doc,
         getDoc,
         setDoc,
+        deleteDoc,
         serverTimestamp,
         collection,
         getDocs,
@@ -818,15 +819,15 @@
               console.warn('Unable to load existing ascents before removal:', loadError);
             }
 
-            await setDoc(
-              ascentRef,
-              {
+            if (Object.keys(remainingRoutes).length === 0) {
+              await deleteDoc(ascentRef);
+            } else {
+              await setDoc(ascentRef, {
                 climber_email: email,
                 updatedAt: serverTimestamp(),
                 routes: remainingRoutes,
-              },
-              { merge: true },
-            );
+              });
+            }
             ascendedRoutes.delete(routeId);
           } else {
             await setDoc(


### PR DESCRIPTION
## Summary
- add Firestore deleteDoc import
- remove a user's ascended record document when the final route is unmarked to eliminate stale entries

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5c451f7e88327901e5ae30ec30d9a