### PR TITLE
Add hollow ring indicator for unascended climbs

### DIFF
--- a/index.html
+++ b/index.html
@@ -970,10 +970,10 @@
           lineWidth,
         });
 
-        if (ascendedRoutes.has(route.id)) {
-          const anchor = scaledPoints[Math.floor(scaledPoints.length / 2)];
-          const radius = Math.max(12, canvas.width * 0.01);
+        const anchor = scaledPoints[Math.floor(scaledPoints.length / 2)];
+        const radius = Math.max(12, canvas.width * 0.01);
 
+        if (ascendedRoutes.has(route.id)) {
           ctx.save();
           ctx.fillStyle = strokeColor;
           ctx.globalAlpha = 0.92;
@@ -989,6 +989,15 @@
           ctx.moveTo(anchor.x - radius * 0.45, anchor.y + radius * 0.1);
           ctx.lineTo(anchor.x - radius * 0.15, anchor.y + radius * 0.45);
           ctx.lineTo(anchor.x + radius * 0.5, anchor.y - radius * 0.35);
+          ctx.stroke();
+          ctx.restore();
+        } else {
+          ctx.save();
+          ctx.lineWidth = Math.max(2, radius * 0.18);
+          ctx.strokeStyle = 'rgba(255, 255, 255, 0.85)';
+          ctx.globalAlpha = 0.9;
+          ctx.beginPath();
+          ctx.arc(anchor.x, anchor.y, radius, 0, Math.PI * 2);
           ctx.stroke();
           ctx.restore();
         }

--- a/index.html
+++ b/index.html
@@ -253,6 +253,15 @@
         content: '✔';
         font-size: 0.9rem;
       }
+
+      .ascend-status.not-ascended {
+        color: rgba(255, 255, 255, 0.7);
+      }
+
+      .ascend-status.not-ascended::before {
+        content: '○';
+        font-size: 0.9rem;
+      }
     </style>
   </head>
   <body>
@@ -612,6 +621,8 @@
 
         if (ascendedRoutes.has(route.id)) {
           appendInfoLine('Ascended', 'ascend-status');
+        } else {
+          appendInfoLine('Not ascended', 'ascend-status not-ascended');
         }
 
         if (currentUser) {

--- a/index.html
+++ b/index.html
@@ -958,20 +958,33 @@
         }
 
         const lineWidth = 10;
+        const anchorIndex = Math.floor(scaledPoints.length / 2);
+        const anchor = scaledPoints[anchorIndex];
+        const radius = Math.max(12, canvas.width * 0.01);
+        const gapRadius = anchor ? Math.max(0, radius - lineWidth / 2) : 0;
+
+        ctx.save();
         ctx.lineWidth = lineWidth;
         ctx.strokeStyle = strokeColor;
         ctx.lineJoin = 'round';
         ctx.lineCap = 'round';
+
+        if (anchor && gapRadius > 0) {
+          ctx.beginPath();
+          ctx.rect(0, 0, canvas.width, canvas.height);
+          ctx.moveTo(anchor.x + gapRadius, anchor.y);
+          ctx.arc(anchor.x, anchor.y, gapRadius, 0, Math.PI * 2);
+          ctx.clip('evenodd');
+        }
+
         ctx.stroke(path);
+        ctx.restore();
 
         routePaths.push({
           route,
           path,
           lineWidth,
         });
-
-        const anchor = scaledPoints[Math.floor(scaledPoints.length / 2)];
-        const radius = Math.max(12, canvas.width * 0.01);
 
         if (ascendedRoutes.has(route.id)) {
           ctx.save();
@@ -993,9 +1006,8 @@
           ctx.restore();
         } else {
           ctx.save();
-          ctx.lineWidth = Math.max(2, radius * 0.18);
-          ctx.strokeStyle = 'rgba(255, 255, 255, 0.85)';
-          ctx.globalAlpha = 0.9;
+          ctx.lineWidth = lineWidth;
+          ctx.strokeStyle = strokeColor;
           ctx.beginPath();
           ctx.arc(anchor.x, anchor.y, radius, 0, Math.PI * 2);
           ctx.stroke();


### PR DESCRIPTION
## Summary
- add styling for a hollow ring icon to represent unascended climbs
- show a tooltip line with the ring icon when a climb has not been ascended

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5c749d8f08327a01263c6998ed1a0