### PR TITLE
Rework setter controls into collapsible sidebar

### DIFF
--- a/setter.html
+++ b/setter.html
@@ -29,20 +29,80 @@
       cursor: crosshair;
     }
 
-    .controls {
+    .control-panel {
       position: fixed;
-      top: 1rem;
-      right: 1rem;
+      top: 0;
+      right: 0;
+      height: 100vh;
+      display: flex;
+      align-items: stretch;
+      gap: 0.25rem;
+      z-index: 12;
+    }
+
+    .panel-toggle {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.35rem;
+      align-self: center;
+      writing-mode: vertical-rl;
+      text-orientation: mixed;
+      border: none;
+      border-radius: 0.85rem 0 0 0.85rem;
+      background: rgba(0, 0, 0, 0.6);
+      color: #fff;
+      padding: 1.5rem 0.65rem;
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      cursor: pointer;
+      transition: background 0.2s ease, transform 0.2s ease;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+    }
+
+    .panel-toggle:hover,
+    .panel-toggle:focus-visible {
+      background: rgba(0, 0, 0, 0.8);
+      transform: translateX(-1px);
+      outline: none;
+    }
+
+    .controls {
       display: flex;
       flex-direction: column;
-      gap: 0.75rem;
+      gap: 1rem;
       align-items: stretch;
-      background: rgba(0, 0, 0, 0.55);
-      padding: 1rem;
-      border-radius: 1rem;
-      backdrop-filter: blur(6px);
-      box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
       width: min(320px, 92vw);
+      max-width: 360px;
+      height: 100vh;
+      padding: 1.25rem;
+      background: rgba(0, 0, 0, 0.55);
+      backdrop-filter: blur(8px);
+      border-radius: 1rem 0 0 1rem;
+      box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+      overflow-y: auto;
+      transition: transform 0.25s ease;
+    }
+
+    .control-panel[data-expanded='false'] .controls {
+      transform: translateX(calc(100% + 0.25rem));
+    }
+
+    .control-panel[data-expanded='true'] .controls {
+      transform: translateX(0);
+    }
+
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
     }
 
     .control-section {
@@ -99,7 +159,8 @@
       border-radius: 0.65rem;
     }
 
-    .controls button {
+    .controls button,
+    .controls a.control-link {
       border: none;
       border-radius: 0.65rem;
       padding: 0.55rem 0.85rem;
@@ -108,6 +169,8 @@
       cursor: pointer;
       transition: transform 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
       color: #111;
+      text-align: center;
+      text-decoration: none;
     }
 
     #clearButton {
@@ -129,7 +192,8 @@
       color: #fff;
     }
 
-    .controls button:hover {
+    .controls button:hover,
+    .controls a.control-link:hover {
       transform: translateY(-2px);
       box-shadow: 0 8px 18px rgba(0, 0, 0, 0.25);
     }
@@ -243,26 +307,6 @@
       box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
     }
 
-    .nav-links {
-      display: flex;
-      gap: 0.5rem;
-      align-items: center;
-    }
-
-    .nav-links a {
-      padding: 0.45rem 0.85rem;
-      border-radius: 999px;
-      background: rgba(255, 255, 255, 0.15);
-      color: inherit;
-      font-size: 0.8rem;
-      text-decoration: none;
-      transition: background 0.2s ease;
-    }
-
-    .nav-links a:hover {
-      background: rgba(255, 255, 255, 0.3);
-    }
-
     .role-badge {
       padding: 0.4rem 0.85rem;
       border-radius: 999px;
@@ -270,6 +314,16 @@
       font-size: 0.8rem;
       letter-spacing: 0.04em;
       text-transform: uppercase;
+    }
+
+    .preview-link {
+      background: rgba(255, 255, 255, 0.25);
+      color: #fff;
+    }
+
+    .preview-link:hover {
+      background: rgba(255, 255, 255, 0.4);
+      color: #111;
     }
 
     .unauthorized {
@@ -344,50 +398,59 @@
 
   <div id="appContent" class="hidden">
     <header class="app-header">
-      <nav class="nav-links" aria-label="Available pages">
-        <a href="index.html">Preview</a>
-      </nav>
       <span id="roleBadge" class="role-badge hidden" aria-live="polite"></span>
     </header>
     <canvas id="drawingCanvas"></canvas>
-    <div class="controls">
-      <div class="control-section">
-        <label class="control-field">
-          <span>Saved routes</span>
-          <select id="routeSelector">
-            <option value="">Create new route…</option>
-          </select>
-        </label>
-        <button id="newRouteButton" type="button">New route</button>
-        <label class="control-field">
-          <span>Setter</span>
-          <input id="routeSetterInput" type="email" placeholder="setter@example.com" autocomplete="off" />
-        </label>
-        <label class="control-field">
-          <span>Title</span>
-          <input id="routeTitleInput" type="text" placeholder="Route title" autocomplete="off" />
-        </label>
-        <label class="control-field">
-          <span>Description</span>
-          <textarea id="routeDescriptionInput" placeholder="Describe the climb"></textarea>
-        </label>
-        <label class="control-field">
-          <span>Date set</span>
-          <input id="routeDateSetInput" type="datetime-local" />
-        </label>
-      </div>
-      <div class="control-section">
-        <label class="control-field">
-          <span>Stroke colour</span>
-          <input type="color" id="colorPicker" value="#ffde59" />
-        </label>
-        <button id="saveButton" type="button">Save route</button>
-        <button id="deleteButton" type="button">Delete route</button>
-        <button id="clearButton" type="button">Clear drawing</button>
-        <button id="signOutButton" type="button">Sign Out</button>
+    <div class="control-panel" data-expanded="true">
+      <button
+        id="controlsToggle"
+        class="panel-toggle"
+        type="button"
+        aria-expanded="true"
+        aria-controls="controlsPanel"
+      >
+        <span class="sr-only">Toggle menu</span>
+        Menu
+      </button>
+      <div id="controlsPanel" class="controls">
+        <div class="control-section">
+          <label class="control-field">
+            <span>Saved routes</span>
+            <select id="routeSelector">
+              <option value="">Create new route…</option>
+            </select>
+          </label>
+          <button id="newRouteButton" type="button">New route</button>
+          <label class="control-field">
+            <span>Setter</span>
+            <input id="routeSetterInput" type="email" placeholder="setter@example.com" autocomplete="off" />
+          </label>
+          <label class="control-field">
+            <span>Title</span>
+            <input id="routeTitleInput" type="text" placeholder="Route title" autocomplete="off" />
+          </label>
+          <label class="control-field">
+            <span>Description</span>
+            <textarea id="routeDescriptionInput" placeholder="Describe the climb"></textarea>
+          </label>
+          <label class="control-field">
+            <span>Date set</span>
+            <input id="routeDateSetInput" type="datetime-local" />
+          </label>
+        </div>
+        <div class="control-section">
+          <label class="control-field">
+            <span>Stroke colour</span>
+            <input type="color" id="colorPicker" value="#ffde59" />
+          </label>
+          <button id="saveButton" type="button">Save route</button>
+          <button id="deleteButton" type="button">Delete route</button>
+          <button id="clearButton" type="button">Clear drawing</button>
+          <button id="signOutButton" type="button">Sign Out</button>
+          <a class="control-link preview-link" href="index.html">Preview</a>
+        </div>
       </div>
     </div>
-  </div>
 
   <div id="unauthorizedNotice" class="unauthorized hidden" role="alert">
     <p><strong>Access denied.</strong> Your account does not have permission to use the setter tools.</p>
@@ -455,6 +518,8 @@
     const newRouteButton = document.getElementById('newRouteButton');
     const deleteButton = document.getElementById('deleteButton');
     const routeStatus = document.getElementById('routeStatus');
+    const controlPanel = document.querySelector('.control-panel');
+    const controlsToggle = document.getElementById('controlsToggle');
 
     deleteButton.disabled = true;
     routeSelector.disabled = true;
@@ -475,6 +540,15 @@
     let currentUserEmail = '';
 
     const routesCache = new Map();
+
+    if (controlsToggle && controlPanel) {
+      controlsToggle.addEventListener('click', () => {
+        const expanded = controlPanel.getAttribute('data-expanded') === 'true';
+        const next = !expanded;
+        controlPanel.setAttribute('data-expanded', String(next));
+        controlsToggle.setAttribute('aria-expanded', String(next));
+      });
+    }
 
     function normalizeDateValue(value) {
       if (!value) {

--- a/setter.html
+++ b/setter.html
@@ -46,10 +46,11 @@
       justify-content: center;
       gap: 0.35rem;
       align-self: center;
+      order: 2;
       writing-mode: vertical-rl;
       text-orientation: mixed;
       border: none;
-      border-radius: 0.85rem 0 0 0.85rem;
+      border-radius: 0 0.85rem 0.85rem 0;
       background: rgba(0, 0, 0, 0.6);
       color: #fff;
       padding: 1.5rem 0.65rem;
@@ -86,11 +87,15 @@
     }
 
     .control-panel[data-expanded='false'] .controls {
-      transform: translateX(calc(100% + 0.25rem));
+      transform: translateX(calc(-100% - 0.25rem));
     }
 
     .control-panel[data-expanded='true'] .controls {
       transform: translateX(0);
+    }
+
+    .controls {
+      order: 1;
     }
 
     .sr-only {
@@ -159,8 +164,7 @@
       border-radius: 0.65rem;
     }
 
-    .controls button,
-    .controls a.control-link {
+    .controls button {
       border: none;
       border-radius: 0.65rem;
       padding: 0.55rem 0.85rem;
@@ -170,7 +174,6 @@
       transition: transform 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
       color: #111;
       text-align: center;
-      text-decoration: none;
     }
 
     #clearButton {
@@ -192,8 +195,12 @@
       color: #fff;
     }
 
-    .controls button:hover,
-    .controls a.control-link:hover {
+    #openPreviewButton {
+      background: rgba(255, 255, 255, 0.4);
+      color: #111;
+    }
+
+    .controls button:hover {
       transform: translateY(-2px);
       box-shadow: 0 8px 18px rgba(0, 0, 0, 0.25);
     }
@@ -292,40 +299,6 @@
       font-size: 0.85rem;
     }
 
-    .app-header {
-      position: fixed;
-      top: 1rem;
-      left: 1rem;
-      z-index: 10;
-      display: flex;
-      gap: 0.75rem;
-      align-items: center;
-      background: rgba(0, 0, 0, 0.55);
-      padding: 0.65rem 1rem;
-      border-radius: 999px;
-      backdrop-filter: blur(6px);
-      box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
-    }
-
-    .role-badge {
-      padding: 0.4rem 0.85rem;
-      border-radius: 999px;
-      background: rgba(255, 255, 255, 0.15);
-      font-size: 0.8rem;
-      letter-spacing: 0.04em;
-      text-transform: uppercase;
-    }
-
-    .preview-link {
-      background: rgba(255, 255, 255, 0.25);
-      color: #fff;
-    }
-
-    .preview-link:hover {
-      background: rgba(255, 255, 255, 0.4);
-      color: #111;
-    }
-
     .unauthorized {
       position: fixed;
       inset: 0;
@@ -397,21 +370,8 @@
   </div>
 
   <div id="appContent" class="hidden">
-    <header class="app-header">
-      <span id="roleBadge" class="role-badge hidden" aria-live="polite"></span>
-    </header>
     <canvas id="drawingCanvas"></canvas>
     <div class="control-panel" data-expanded="true">
-      <button
-        id="controlsToggle"
-        class="panel-toggle"
-        type="button"
-        aria-expanded="true"
-        aria-controls="controlsPanel"
-      >
-        <span class="sr-only">Toggle menu</span>
-        Menu
-      </button>
       <div id="controlsPanel" class="controls">
         <div class="control-section">
           <label class="control-field">
@@ -447,10 +407,22 @@
           <button id="deleteButton" type="button">Delete route</button>
           <button id="clearButton" type="button">Clear drawing</button>
           <button id="signOutButton" type="button">Sign Out</button>
-          <a class="control-link preview-link" href="index.html">Preview</a>
+          <button id="openPreviewButton" type="button">Open Preview</button>
         </div>
       </div>
+      <button
+        id="controlsToggle"
+        class="panel-toggle"
+        type="button"
+        aria-expanded="true"
+        aria-controls="controlsPanel"
+      >
+        <span class="sr-only">Toggle menu</span>
+        Menu
+      </button>
     </div>
+
+  </div>
 
   <div id="unauthorizedNotice" class="unauthorized hidden" role="alert">
     <p><strong>Access denied.</strong> Your account does not have permission to use the setter tools.</p>
@@ -509,7 +481,6 @@
     const signOutButton = document.getElementById('signOutButton');
     const unauthorizedSignOut = document.getElementById('unauthorizedSignOut');
     const unauthorizedNotice = document.getElementById('unauthorizedNotice');
-    const roleBadge = document.getElementById('roleBadge');
     const routeSelector = document.getElementById('routeSelector');
     const routeSetterInput = document.getElementById('routeSetterInput');
     const routeTitleInput = document.getElementById('routeTitleInput');
@@ -520,6 +491,7 @@
     const routeStatus = document.getElementById('routeStatus');
     const controlPanel = document.querySelector('.control-panel');
     const controlsToggle = document.getElementById('controlsToggle');
+    const openPreviewButton = document.getElementById('openPreviewButton');
 
     deleteButton.disabled = true;
     routeSelector.disabled = true;
@@ -547,6 +519,12 @@
         const next = !expanded;
         controlPanel.setAttribute('data-expanded', String(next));
         controlsToggle.setAttribute('aria-expanded', String(next));
+      });
+    }
+
+    if (openPreviewButton) {
+      openPreviewButton.addEventListener('click', () => {
+        window.location.href = 'index.html';
       });
     }
 
@@ -1286,21 +1264,17 @@
       }
     }
 
-    function handleUnauthorized(role) {
+    function handleUnauthorized() {
       appContent.classList.add('hidden');
       unauthorizedNotice.classList.remove('hidden');
-      roleBadge.textContent = role ? role.toUpperCase() : '';
-      roleBadge.classList.toggle('hidden', !role);
       routeSelector.disabled = true;
       deleteButton.disabled = true;
       clearStatus();
     }
 
-    function handleAuthorized(role) {
+    function handleAuthorized() {
       unauthorizedNotice.classList.add('hidden');
       appContent.classList.remove('hidden');
-      roleBadge.textContent = role.toUpperCase();
-      roleBadge.classList.remove('hidden');
       routeSelector.disabled = false;
     }
 
@@ -1318,11 +1292,11 @@
         }
 
         if (role !== 'setter') {
-          handleUnauthorized(role);
+          handleUnauthorized();
           return;
         }
 
-        handleAuthorized(role);
+        handleAuthorized();
 
         try {
           await loadRoutesList(currentRouteKey);
@@ -1339,7 +1313,6 @@
         authOverlay.classList.remove('hidden');
         appContent.classList.add('hidden');
         unauthorizedNotice.classList.add('hidden');
-        roleBadge.classList.add('hidden');
         routeSelector.disabled = true;
         deleteButton.disabled = true;
         authForm.reset();

--- a/setter.html
+++ b/setter.html
@@ -36,8 +36,11 @@
       height: 100vh;
       display: flex;
       align-items: stretch;
-      gap: 0.25rem;
+      gap: 0;
       z-index: 12;
+      --toggle-visible-width: 52px;
+      transition: transform 0.25s ease;
+      transform: translateX(0);
     }
 
     .panel-toggle {
@@ -46,11 +49,11 @@
       justify-content: center;
       gap: 0.35rem;
       align-self: center;
-      order: 2;
+      order: 1;
       writing-mode: vertical-rl;
       text-orientation: mixed;
       border: none;
-      border-radius: 0 0.85rem 0.85rem 0;
+      border-radius: 0.85rem 0 0 0.85rem;
       background: rgba(0, 0, 0, 0.6);
       color: #fff;
       padding: 1.5rem 0.65rem;
@@ -83,19 +86,15 @@
       border-radius: 1rem 0 0 1rem;
       box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
       overflow-y: auto;
-      transition: transform 0.25s ease;
-    }
-
-    .control-panel[data-expanded='false'] .controls {
-      transform: translateX(calc(-100% - 0.25rem));
-    }
-
-    .control-panel[data-expanded='true'] .controls {
-      transform: translateX(0);
+      transition: box-shadow 0.25s ease, background 0.25s ease;
     }
 
     .controls {
-      order: 1;
+      order: 2;
+    }
+
+    .control-panel[data-expanded='false'] {
+      transform: translateX(calc(100% - var(--toggle-visible-width)));
     }
 
     .sr-only {
@@ -493,6 +492,17 @@
     const controlsToggle = document.getElementById('controlsToggle');
     const openPreviewButton = document.getElementById('openPreviewButton');
 
+    const updatePanelMeasurements = () => {
+      if (!controlPanel || !controlsToggle) {
+        return;
+      }
+
+      const { width } = controlsToggle.getBoundingClientRect();
+      if (Number.isFinite(width) && width > 0) {
+        controlPanel.style.setProperty('--toggle-visible-width', `${Math.ceil(width)}px`);
+      }
+    };
+
     deleteButton.disabled = true;
     routeSelector.disabled = true;
 
@@ -514,12 +524,22 @@
     const routesCache = new Map();
 
     if (controlsToggle && controlPanel) {
+      updatePanelMeasurements();
+
       controlsToggle.addEventListener('click', () => {
         const expanded = controlPanel.getAttribute('data-expanded') === 'true';
         const next = !expanded;
         controlPanel.setAttribute('data-expanded', String(next));
         controlsToggle.setAttribute('aria-expanded', String(next));
+        requestAnimationFrame(updatePanelMeasurements);
       });
+
+      window.addEventListener('resize', updatePanelMeasurements);
+
+      if ('ResizeObserver' in window) {
+        const resizeObserver = new ResizeObserver(updatePanelMeasurements);
+        resizeObserver.observe(controlsToggle);
+      }
     }
 
     if (openPreviewButton) {


### PR DESCRIPTION
## Summary
- replace the floating setter controls with a fixed, collapsible sidebar that slides in from the right
- ensure the sidebar content scrolls to keep long menus accessible and move the Preview navigation link inside it
- add a toggle tab for quickly collapsing or expanding the controls

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e5ceb2493c83279a50b37d2dfdd7df