### PR TITLE
Remove role search tooltip message

### DIFF
--- a/setter.html
+++ b/setter.html
@@ -2317,7 +2317,7 @@
       }
       updateRoleActionState();
       if (!roleResultsList || !roleResultsList.value || !roleSearchResults.has(roleResultsList.value)) {
-        setRoleStatus('Search for a user to grant setter access.', 'info');
+        clearRoleStatus();
       }
     }
 


### PR DESCRIPTION
## Summary
- stop showing the informational tooltip that prompted searching for a user before granting setter access
- clear the status instead when no role search result is selected

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e5f04c769883279a9db55d48107ee0