### PR TITLE
Gracefully handle missing role metadata during auth

### DIFF
--- a/index.html
+++ b/index.html
@@ -628,10 +628,16 @@
         }
 
         const roleRef = doc(db, 'roles', user.uid);
-        const existingSnap = await getDoc(roleRef);
 
-        if (existingSnap.exists()) {
-          return existingSnap.data();
+        try {
+          const existingSnap = await getDoc(roleRef);
+          if (existingSnap.exists()) {
+            const existingData = existingSnap.data() ?? {};
+            const existingRole = typeof existingData.role === 'string' ? existingData.role : 'climber';
+            return { ...existingData, role: existingRole };
+          }
+        } catch (error) {
+          console.warn('Failed to inspect existing role information:', error);
         }
 
         let role = 'climber';
@@ -652,7 +658,13 @@
           updatedAt: serverTimestamp(),
         };
 
-        await setDoc(roleRef, roleData);
+        try {
+          await setDoc(roleRef, roleData);
+        } catch (error) {
+          console.error('Failed to persist role information:', error);
+          return roleData;
+        }
+
         return roleData;
       }
 
@@ -665,15 +677,20 @@
           const roleRef = doc(db, 'roles', user.uid);
           const roleSnap = await getDoc(roleRef);
           if (roleSnap.exists()) {
-            return roleSnap.data().role;
+            const data = roleSnap.data() ?? {};
+            const normalizedRole = typeof data.role === 'string' ? data.role : 'climber';
+            return normalizedRole;
           }
 
           const createdRole = await ensureUserRole(user);
-          return createdRole ? createdRole.role : null;
+          if (createdRole && typeof createdRole.role === 'string') {
+            return createdRole.role;
+          }
         } catch (error) {
           console.error('Failed to fetch user role:', error);
-          return null;
         }
+
+        return 'climber';
       }
 
       function updateNavigationForRole(role) {

--- a/setter.html
+++ b/setter.html
@@ -2248,22 +2248,29 @@
       }
 
       const roleRef = doc(db, 'roles', user.uid);
-      const existingSnap = await getDoc(roleRef);
 
-      if (existingSnap.exists()) {
-        const existingData = existingSnap.data() || {};
-        if (existingData.email && !existingData.emailLower) {
-          try {
-            await setDoc(
-              roleRef,
-              { emailLower: String(existingData.email).toLowerCase(), updatedAt: serverTimestamp() },
-              { merge: true },
-            );
-          } catch (error) {
-            console.warn('Failed to backfill emailLower field:', error);
+      try {
+        const existingSnap = await getDoc(roleRef);
+        if (existingSnap.exists()) {
+          const existingData = existingSnap.data() || {};
+          const normalizedRole = typeof existingData.role === 'string' ? existingData.role : 'climber';
+
+          if (existingData.email && !existingData.emailLower) {
+            try {
+              await setDoc(
+                roleRef,
+                { emailLower: String(existingData.email).toLowerCase(), updatedAt: serverTimestamp() },
+                { merge: true },
+              );
+            } catch (error) {
+              console.warn('Failed to backfill emailLower field:', error);
+            }
           }
+
+          return { ...existingData, role: normalizedRole };
         }
-        return existingSnap.data();
+      } catch (error) {
+        console.warn('Failed to inspect existing role information:', error);
       }
 
       let role = 'climber';
@@ -2287,7 +2294,13 @@
         updatedAt: serverTimestamp(),
       };
 
-      await setDoc(roleRef, roleData);
+      try {
+        await setDoc(roleRef, roleData);
+      } catch (error) {
+        console.error('Failed to persist role information:', error);
+        return roleData;
+      }
+
       return roleData;
     }
 
@@ -2300,15 +2313,20 @@
         const roleRef = doc(db, 'roles', user.uid);
         const roleSnap = await getDoc(roleRef);
         if (roleSnap.exists()) {
-          return roleSnap.data().role;
+          const data = roleSnap.data() || {};
+          const normalizedRole = typeof data.role === 'string' ? data.role : 'climber';
+          return normalizedRole;
         }
 
         const createdRole = await ensureUserRole(user);
-        return createdRole ? createdRole.role : null;
+        if (createdRole && typeof createdRole.role === 'string') {
+          return createdRole.role;
+        }
       } catch (error) {
         console.error('Failed to fetch user role:', error);
-        return null;
       }
+
+      return 'climber';
     }
 
     function handleUnauthorized() {


### PR DESCRIPTION
## Summary
- default users to the climber role when role metadata cannot be fetched
- guard role document creation so authentication is not aborted on Firestore errors
- normalise role lookups to handle missing role values consistently across the app

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e6050db1a08327bb3c6c0713d988b0