### PR TITLE
Align route tooltip accents with route color

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,11 +251,7 @@
         --tooltip-on-accent: #111;
         position: fixed;
         pointer-events: none;
-        background: linear-gradient(
-          135deg,
-          rgba(var(--tooltip-accent-rgb, 126, 217, 87), 0.48),
-          rgba(0, 0, 0, 0.82)
-        );
+        background: rgba(var(--tooltip-accent-rgb, 126, 217, 87), 0.72);
         color: #fff;
         padding: 0.75rem 1rem;
         border-radius: 0.75rem;

--- a/index.html
+++ b/index.html
@@ -248,11 +248,12 @@
         --tooltip-accent-rgb: 126, 217, 87;
         --tooltip-accent-soft: rgba(126, 217, 87, 0.18);
         --tooltip-accent-strong: rgba(126, 217, 87, 0.85);
-        --tooltip-on-accent: #111;
+        --tooltip-on-accent: #000;
+        --tooltip-foreground: #fff;
         position: fixed;
         pointer-events: none;
         background: rgba(var(--tooltip-accent-rgb, 126, 217, 87), 0.72);
-        color: #fff;
+        color: var(--tooltip-foreground, #fff);
         padding: 0.75rem 1rem;
         border-radius: 0.75rem;
         border: 1px solid rgba(var(--tooltip-accent-rgb, 126, 217, 87), 0.45);
@@ -316,7 +317,7 @@
 
       .ascend-toggle.ascended {
         background: var(--tooltip-accent-strong, rgba(126, 217, 87, 0.85));
-        color: var(--tooltip-on-accent, #111);
+        color: var(--tooltip-on-accent, #000);
         box-shadow: 0 10px 18px rgba(var(--tooltip-accent-rgb, 126, 217, 87), 0.25);
       }
 
@@ -597,8 +598,10 @@
         const rgbString = `${r}, ${g}, ${b}`;
         const accent = parsed.hex ? parsed.hex : `rgb(${rgbString})`;
 
-        const luminance = (0.2126 * (r / 255) + 0.7152 * (g / 255) + 0.0722 * (b / 255));
-        const onAccent = luminance > 0.6 ? '#111' : '#f9f9f9';
+        const luminance = 0.2126 * (r / 255) + 0.7152 * (g / 255) + 0.0722 * (b / 255);
+        const isBright = luminance > 0.6;
+        const onAccent = isBright ? '#000' : '#f9f9f9';
+        const foreground = isBright ? '#000' : '#fff';
 
         return {
           accent,
@@ -606,6 +609,7 @@
           soft: `rgba(${rgbString}, 0.18)`,
           strong: `rgba(${rgbString}, 0.85)`,
           onAccent,
+          foreground,
         };
       }
 
@@ -620,13 +624,15 @@
         const rgb = scheme?.rgb ?? '126, 217, 87';
         const soft = scheme?.soft ?? 'rgba(126, 217, 87, 0.18)';
         const strong = scheme?.strong ?? 'rgba(126, 217, 87, 0.85)';
-        const onAccent = scheme?.onAccent ?? '#111';
+        const onAccent = scheme?.onAccent ?? '#000';
+        const foreground = scheme?.foreground ?? '#fff';
 
         tooltip.style.setProperty('--tooltip-accent', accent);
         tooltip.style.setProperty('--tooltip-accent-rgb', rgb);
         tooltip.style.setProperty('--tooltip-accent-soft', soft);
         tooltip.style.setProperty('--tooltip-accent-strong', strong);
         tooltip.style.setProperty('--tooltip-on-accent', onAccent);
+        tooltip.style.setProperty('--tooltip-foreground', foreground);
       }
 
       function closeInfoPopover() {

--- a/index.html
+++ b/index.html
@@ -253,7 +253,7 @@
         pointer-events: none;
         background: linear-gradient(
           135deg,
-          rgba(var(--tooltip-accent-rgb, 126, 217, 87), 0.24),
+          rgba(var(--tooltip-accent-rgb, 126, 217, 87), 0.48),
           rgba(0, 0, 0, 0.82)
         );
         color: #fff;

--- a/index.html
+++ b/index.html
@@ -389,7 +389,7 @@
 
       .grade-clear {
         background: rgba(255, 255, 255, 0.15);
-        color: #fff;
+        color: var(--tooltip-foreground, #fff);
       }
 
       .grade-clear:not(:disabled):hover {

--- a/index.html
+++ b/index.html
@@ -244,13 +244,23 @@
       }
 
       .route-tooltip {
+        --tooltip-accent: #7ed957;
+        --tooltip-accent-rgb: 126, 217, 87;
+        --tooltip-accent-soft: rgba(126, 217, 87, 0.18);
+        --tooltip-accent-strong: rgba(126, 217, 87, 0.85);
+        --tooltip-on-accent: #111;
         position: fixed;
         pointer-events: none;
-        background: rgba(0, 0, 0, 0.75);
+        background: linear-gradient(
+          135deg,
+          rgba(var(--tooltip-accent-rgb, 126, 217, 87), 0.24),
+          rgba(0, 0, 0, 0.82)
+        );
         color: #fff;
         padding: 0.75rem 1rem;
         border-radius: 0.75rem;
-        box-shadow: 0 12px 30px rgba(0, 0, 0, 0.45);
+        border: 1px solid rgba(var(--tooltip-accent-rgb, 126, 217, 87), 0.45);
+        box-shadow: 0 12px 30px rgba(var(--tooltip-accent-rgb, 126, 217, 87), 0.25);
         font-size: 0.85rem;
         line-height: 1.4;
         max-width: min(280px, 80vw);
@@ -299,18 +309,19 @@
         font-weight: 600;
         cursor: pointer;
         transition: transform 0.15s ease, box-shadow 0.15s ease;
-        background: rgba(126, 217, 87, 0.15);
-        color: #7ed957;
+        background: var(--tooltip-accent-soft, rgba(126, 217, 87, 0.18));
+        color: var(--tooltip-accent, #7ed957);
       }
 
       .ascend-toggle:hover {
         transform: translateY(-1px);
-        box-shadow: 0 10px 18px rgba(126, 217, 87, 0.25);
+        box-shadow: 0 10px 18px rgba(var(--tooltip-accent-rgb, 126, 217, 87), 0.25);
       }
 
       .ascend-toggle.ascended {
-        background: rgba(126, 217, 87, 0.85);
-        color: #111;
+        background: var(--tooltip-accent-strong, rgba(126, 217, 87, 0.85));
+        color: var(--tooltip-on-accent, #111);
+        box-shadow: 0 10px 18px rgba(var(--tooltip-accent-rgb, 126, 217, 87), 0.25);
       }
 
       .grade-section {
@@ -370,13 +381,13 @@
       }
 
       .grade-submit {
-        background: rgba(126, 217, 87, 0.85);
-        color: #111;
+        background: var(--tooltip-accent-strong, rgba(126, 217, 87, 0.85));
+        color: var(--tooltip-on-accent, #111);
       }
 
       .grade-submit:not(:disabled):hover {
         transform: translateY(-1px);
-        box-shadow: 0 10px 18px rgba(126, 217, 87, 0.25);
+        box-shadow: 0 10px 18px rgba(var(--tooltip-accent-rgb, 126, 217, 87), 0.25);
       }
 
       .grade-clear {
@@ -399,7 +410,7 @@
         align-items: center;
         gap: 0.35rem;
         font-weight: 600;
-        color: #7ed957;
+        color: var(--tooltip-accent, #7ed957);
       }
 
       .ascend-status::before {
@@ -530,6 +541,97 @@
       const tooltip = document.getElementById('routeTooltip');
       const infoButton = document.getElementById('infoButton');
       const infoPopover = document.getElementById('infoPopover');
+
+      const tooltipColorCanvas = document.createElement('canvas');
+      const tooltipColorContext = tooltipColorCanvas.getContext('2d');
+
+      function parseTooltipColor(color) {
+        if (!tooltipColorContext || typeof color !== 'string') {
+          return null;
+        }
+
+        let normalized;
+        try {
+          tooltipColorContext.fillStyle = '#000000';
+          tooltipColorContext.fillStyle = color;
+          normalized = tooltipColorContext.fillStyle;
+        } catch (error) {
+          return null;
+        }
+
+        if (typeof normalized !== 'string' || !normalized) {
+          return null;
+        }
+
+        if (/^#[0-9a-f]{6}$/i.test(normalized)) {
+          const r = parseInt(normalized.slice(1, 3), 16);
+          const g = parseInt(normalized.slice(3, 5), 16);
+          const b = parseInt(normalized.slice(5, 7), 16);
+          return { r, g, b, hex: normalized };
+        }
+
+        const rgbaMatch = normalized
+          .replace(/\s+/g, '')
+          .match(/^rgba?\((\d+),(\d+),(\d+)(?:,(0|1|0?\.\d+))?\)$/i);
+
+        if (rgbaMatch) {
+          const [, r, g, b] = rgbaMatch;
+          return {
+            r: Number.parseInt(r, 10),
+            g: Number.parseInt(g, 10),
+            b: Number.parseInt(b, 10),
+            hex: null,
+          };
+        }
+
+        return null;
+      }
+
+      function deriveTooltipColorScheme(color) {
+        const parsed = parseTooltipColor(color);
+
+        if (!parsed) {
+          return null;
+        }
+
+        const clamp = (value) => Math.max(0, Math.min(255, value));
+        const r = clamp(parsed.r);
+        const g = clamp(parsed.g);
+        const b = clamp(parsed.b);
+        const rgbString = `${r}, ${g}, ${b}`;
+        const accent = parsed.hex ? parsed.hex : `rgb(${rgbString})`;
+
+        const luminance = (0.2126 * (r / 255) + 0.7152 * (g / 255) + 0.0722 * (b / 255));
+        const onAccent = luminance > 0.6 ? '#111' : '#f9f9f9';
+
+        return {
+          accent,
+          rgb: rgbString,
+          soft: `rgba(${rgbString}, 0.18)`,
+          strong: `rgba(${rgbString}, 0.85)`,
+          onAccent,
+        };
+      }
+
+      function applyTooltipColorScheme(route) {
+        if (!tooltip) {
+          return;
+        }
+
+        const scheme = deriveTooltipColorScheme(route?.strokeColor);
+
+        const accent = scheme?.accent ?? '#7ed957';
+        const rgb = scheme?.rgb ?? '126, 217, 87';
+        const soft = scheme?.soft ?? 'rgba(126, 217, 87, 0.18)';
+        const strong = scheme?.strong ?? 'rgba(126, 217, 87, 0.85)';
+        const onAccent = scheme?.onAccent ?? '#111';
+
+        tooltip.style.setProperty('--tooltip-accent', accent);
+        tooltip.style.setProperty('--tooltip-accent-rgb', rgb);
+        tooltip.style.setProperty('--tooltip-accent-soft', soft);
+        tooltip.style.setProperty('--tooltip-accent-strong', strong);
+        tooltip.style.setProperty('--tooltip-on-accent', onAccent);
+      }
 
       function closeInfoPopover() {
         if (!infoPopover) {
@@ -1094,6 +1196,8 @@
         if (!tooltip) {
           return;
         }
+
+        applyTooltipColorScheme(route);
 
         const fragment = document.createDocumentFragment();
         const ariaLines = [];


### PR DESCRIPTION
## Summary
- derive tooltip color variables from each route's stroke color and apply them as CSS custom properties
- restyle the route tooltip, ascend button, grade submit button, and status text to consume the dynamic accent variables

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e6287c85c083279cb6b1d1a0d08ca4