### PR TITLE
Remove climber role in favor of default access

### DIFF
--- a/index.html
+++ b/index.html
@@ -499,6 +499,7 @@
         getDocs,
         query,
         limit,
+        where,
       } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js';
 
       const firebaseConfig = {
@@ -634,10 +635,12 @@
           return existingSnap.data();
         }
 
-        let role = 'climber';
+        let role = 'default';
 
         try {
-          const snapshot = await getDocs(query(collection(db, 'roles'), limit(1)));
+          const snapshot = await getDocs(
+            query(collection(db, 'roles'), where('role', '==', 'setter'), limit(1)),
+          );
           if (snapshot.empty) {
             role = 'setter';
           }
@@ -665,14 +668,15 @@
           const roleRef = doc(db, 'roles', user.uid);
           const roleSnap = await getDoc(roleRef);
           if (roleSnap.exists()) {
-            return roleSnap.data().role;
+            const data = roleSnap.data();
+            return typeof data.role === 'string' ? data.role.trim() : 'default';
           }
 
           const createdRole = await ensureUserRole(user);
-          return createdRole ? createdRole.role : null;
+          return createdRole ? createdRole.role : 'default';
         } catch (error) {
           console.error('Failed to fetch user role:', error);
-          return null;
+          return 'default';
         }
       }
 
@@ -686,12 +690,6 @@
 
           currentUser = user;
           const role = await resolveUserRole(user);
-
-          if (!role) {
-            authError.textContent = 'Unable to determine your role. Please try again later.';
-            await signOut(auth);
-            return;
-          }
 
           updateNavigationForRole(role);
           appContent.classList.remove('hidden');

--- a/setter.html
+++ b/setter.html
@@ -672,6 +672,7 @@
       getDocs,
       query,
       limit,
+      where,
       orderBy,
       startAt,
       endAt,
@@ -1275,14 +1276,14 @@
           await setDoc(
             roleRef,
             {
-              role: 'climber',
+              role: 'default',
               updatedAt: serverTimestamp(),
               email,
               emailLower: email.toLowerCase(),
             },
             { merge: true },
           );
-          roleSearchResults.set(selectedId, { ...entry, role: 'climber' });
+          roleSearchResults.set(selectedId, { ...entry, role: 'default' });
           updateRoleOptionLabel(selectedId);
           updateRoleActionState();
           setRoleStatus(`Setter role removed from ${entry.email}.`, 'success');
@@ -1577,7 +1578,7 @@
         snapshot.forEach((docSnap) => {
           const data = docSnap.data() || {};
           const email = typeof data.email === 'string' ? data.email.trim() : '';
-          const role = typeof data.role === 'string' ? data.role.trim() : 'climber';
+          const role = typeof data.role === 'string' ? data.role.trim() : 'default';
           if (!email) {
             return;
           }
@@ -2266,12 +2267,14 @@
         return existingSnap.data();
       }
 
-      let role = 'climber';
+      let role = 'default';
 
       const email = typeof user.email === 'string' ? user.email.trim() : '';
 
       try {
-        const snapshot = await getDocs(query(collection(db, 'roles'), limit(1)));
+        const snapshot = await getDocs(
+          query(collection(db, 'roles'), where('role', '==', 'setter'), limit(1)),
+        );
         if (snapshot.empty) {
           role = 'setter';
         }
@@ -2300,14 +2303,15 @@
         const roleRef = doc(db, 'roles', user.uid);
         const roleSnap = await getDoc(roleRef);
         if (roleSnap.exists()) {
-          return roleSnap.data().role;
+          const data = roleSnap.data();
+          return typeof data.role === 'string' ? data.role.trim() : 'default';
         }
 
         const createdRole = await ensureUserRole(user);
-        return createdRole ? createdRole.role : null;
+        return createdRole ? createdRole.role : 'default';
       } catch (error) {
         console.error('Failed to fetch user role:', error);
-        return null;
+        return 'default';
       }
     }
 


### PR DESCRIPTION
## Summary
- replace the deprecated climber role with a default role in the preview app so non-setter users stay signed in while setter navigation remains gated
- update the setter tools to treat non-setter accounts as default users, including role management and queries for assigning setter access

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e6335df9dc83279618ab587b67320b