### PR TITLE
Simplify setter role management workflow

### DIFF
--- a/setter.html
+++ b/setter.html
@@ -313,20 +313,6 @@
       text-align: center;
     }
 
-    #roleResultsList {
-      width: 100%;
-      min-height: 8rem;
-      border-radius: 0.65rem;
-      border: 1px solid rgba(255, 255, 255, 0.15);
-      background: rgba(0, 0, 0, 0.35);
-      color: inherit;
-      padding: 0.35rem 0.5rem;
-    }
-
-    #roleResultsList option {
-      padding: 0.25rem 0.35rem;
-    }
-
     #clearButton {
       background: rgba(255, 116, 116, 0.9);
       color: #111;
@@ -338,11 +324,6 @@
 
     #grantSetterButton {
       background: rgba(126, 217, 87, 0.85);
-      color: #111;
-    }
-
-    #removeSetterButton {
-      background: rgba(255, 116, 116, 0.9);
       color: #111;
     }
 
@@ -612,22 +593,14 @@
         <div class="control-section">
           <label class="control-field">
             <span>Grant setter access</span>
-            <div class="control-row">
-              <input
-                id="roleSearchInput"
-                type="search"
-                placeholder="Search users by email"
-                autocomplete="off"
-              />
-              <button id="roleLookupButton" type="button">Lookup</button>
-            </div>
-          </label>
-          <label class="control-field">
-            <span>Matching users</span>
-            <select id="roleResultsList" size="4"></select>
+            <input
+              id="roleEmailInput"
+              type="email"
+              placeholder="user@example.com"
+              autocomplete="off"
+            />
           </label>
           <button id="grantSetterButton" type="button">Grant setter role</button>
-          <button id="removeSetterButton" type="button">Remove setter role</button>
           <p
             id="roleStatusMessage"
             class="status-message hidden"
@@ -678,9 +651,6 @@
       query,
       limit,
       where,
-      orderBy,
-      startAt,
-      endAt,
       deleteDoc,
       deleteField,
     } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js';
@@ -721,11 +691,8 @@
     const controlPanel = document.querySelector('.control-panel');
     const controlsToggle = document.getElementById('controlsToggle');
     const openPreviewButton = document.getElementById('openPreviewButton');
-    const roleSearchInput = document.getElementById('roleSearchInput');
-    const roleLookupButton = document.getElementById('roleLookupButton');
-    const roleResultsList = document.getElementById('roleResultsList');
+    const roleEmailInput = document.getElementById('roleEmailInput');
     const grantSetterButton = document.getElementById('grantSetterButton');
-    const removeSetterButton = document.getElementById('removeSetterButton');
     const roleStatusMessage = document.getElementById('roleStatusMessage');
 
     const updatePanelMeasurements = () => {
@@ -744,8 +711,8 @@
     if (grantSetterButton) {
       grantSetterButton.disabled = true;
     }
-    if (removeSetterButton) {
-      removeSetterButton.disabled = true;
+    if (roleEmailInput) {
+      roleEmailInput.disabled = true;
     }
 
     const canvasContainer = document.querySelector('.canvas-container');
@@ -778,8 +745,12 @@
     let isCanvasScrollable = false;
 
     const routesCache = new Map();
-    const roleSearchResults = new Map();
-    const MAX_ROLE_RESULTS = 10;
+    const normalizeEmail = (value) => {
+      if (typeof value !== 'string') {
+        return '';
+      }
+      return value.trim().toLowerCase();
+    };
 
     if (controlsToggle && controlPanel) {
       updatePanelMeasurements();
@@ -1158,149 +1129,112 @@
       });
     }
 
-    if (roleLookupButton) {
-      roleLookupButton.addEventListener('click', () => {
-        performRoleLookup();
-      });
+    function setRoleControlsEnabled(enabled) {
+      const allow = Boolean(enabled);
+      if (grantSetterButton) {
+        grantSetterButton.disabled = !allow;
+      }
+      if (roleEmailInput) {
+        roleEmailInput.disabled = !allow;
+      }
     }
 
-    if (roleSearchInput) {
-      roleSearchInput.addEventListener('keydown', (event) => {
-        if (event.key === 'Enter') {
-          event.preventDefault();
-          performRoleLookup();
-        }
-      });
+    function resetRoleManagementUI(message = '') {
+      if (roleEmailInput) {
+        roleEmailInput.value = '';
+      }
+
+      if (message) {
+        setRoleStatus(message, 'info');
+      } else {
+        clearRoleStatus();
+      }
     }
 
-    if (roleResultsList) {
-      roleResultsList.addEventListener('change', () => {
-        updateRoleActionState();
-        const selectedId = roleResultsList.value;
-        if (!selectedId || !roleSearchResults.has(selectedId)) {
-          setRoleStatus('Select a user to manage setter access.', 'info');
-          return;
-        }
+    function isLikelyEmail(value) {
+      if (typeof value !== 'string') {
+        return false;
+      }
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return false;
+      }
 
-        const entry = roleSearchResults.get(selectedId);
-        const isSelf = currentUserId && selectedId === currentUserId;
-        if (isSelf) {
-          setRoleStatus('You cannot change your own role.', 'info');
-        } else if (entry.role === 'setter') {
-          setRoleStatus(`Ready to remove setter role from ${entry.email}.`, 'info');
-        } else {
-          setRoleStatus(`Ready to grant setter role to ${entry.email}.`, 'info');
-        }
-      });
+      return /.+@.+\..+/.test(trimmed);
     }
 
-    if (grantSetterButton) {
+    async function findRoleByEmail(normalizedEmail) {
+      try {
+        const snapshot = await getDocs(
+          query(collection(db, 'roles'), where('emailLower', '==', normalizedEmail), limit(1)),
+        );
+
+        if (snapshot.empty) {
+          return null;
+        }
+
+        const match = snapshot.docs[0];
+        return { id: match.id, data: match.data() || {} };
+      } catch (error) {
+        console.error('Failed to search for existing role document:', error);
+        throw error;
+      }
+    }
+
+    if (grantSetterButton && roleEmailInput) {
       grantSetterButton.addEventListener('click', async () => {
-        const selectedId = roleResultsList?.value || '';
-        if (!selectedId || !roleSearchResults.has(selectedId)) {
-          setRoleStatus('Select a user to manage setter access.', 'info');
-          updateRoleActionState();
+        const rawEmail = roleEmailInput.value;
+        const trimmedEmail = typeof rawEmail === 'string' ? rawEmail.trim() : '';
+
+        if (!trimmedEmail) {
+          setRoleStatus('Enter the user\'s email address.', 'info');
           return;
         }
 
-        const entry = roleSearchResults.get(selectedId);
-        const isSelf = currentUserId && selectedId === currentUserId;
-        if (isSelf) {
-          setRoleStatus('You cannot change your own role.', 'info');
-          updateRoleActionState();
+        if (!isLikelyEmail(trimmedEmail)) {
+          setRoleStatus('Enter a valid email address.', 'error');
           return;
         }
 
-        if (entry.role === 'setter') {
-          setRoleStatus(`${entry.email} is already a setter. Use “Remove setter role” to revoke access.`, 'info');
-          updateRoleActionState();
-          return;
-        }
+        const normalizedEmail = normalizeEmail(trimmedEmail);
 
         try {
-          grantSetterButton.disabled = true;
-          if (removeSetterButton) {
-            removeSetterButton.disabled = true;
+          setRoleControlsEnabled(false);
+          setRoleStatus(`Granting setter role to ${trimmedEmail}…`, 'info');
+
+          const existingRole = await findRoleByEmail(normalizedEmail);
+          const roleId = existingRole?.id ?? normalizedEmail;
+          const roleRef = doc(db, 'roles', roleId);
+          const payload = {
+            role: 'setter',
+            email: trimmedEmail,
+            emailLower: normalizedEmail,
+            updatedAt: serverTimestamp(),
+          };
+
+          if (!existingRole?.data?.createdAt) {
+            payload.createdAt = serverTimestamp();
           }
-          setRoleStatus(`Granting setter role to ${entry.email}…`, 'info');
-          const roleRef = doc(db, 'roles', selectedId);
-          const email = entry.email || '';
-          await setDoc(
-            roleRef,
-            {
-              role: 'setter',
-              updatedAt: serverTimestamp(),
-              email,
-              emailLower: email.toLowerCase(),
-            },
-            { merge: true },
-          );
-          roleSearchResults.set(selectedId, { ...entry, role: 'setter' });
-          updateRoleOptionLabel(selectedId);
-          updateRoleActionState();
-          setRoleStatus(`Setter role granted to ${entry.email}.`, 'success');
+
+          await setDoc(roleRef, payload, { merge: true });
+
+          setRoleStatus(`Setter role granted to ${trimmedEmail}.`, 'success');
+          if (roleEmailInput) {
+            roleEmailInput.value = '';
+          }
         } catch (error) {
           console.error('Failed to grant setter role:', error);
           setRoleStatus('Unable to grant setter role. Please try again.', 'error');
-          updateRoleActionState();
-        }
-      });
-    }
-
-    if (removeSetterButton) {
-      removeSetterButton.addEventListener('click', async () => {
-        const selectedId = roleResultsList?.value || '';
-        if (!selectedId || !roleSearchResults.has(selectedId)) {
-          setRoleStatus('Select a user to manage setter access.', 'info');
-          updateRoleActionState();
-          return;
-        }
-
-        const entry = roleSearchResults.get(selectedId);
-        const isSelf = currentUserId && selectedId === currentUserId;
-        if (isSelf) {
-          setRoleStatus('You cannot change your own role.', 'info');
-          updateRoleActionState();
-          return;
-        }
-
-        if (entry.role !== 'setter') {
-          setRoleStatus(`${entry.email} is not a setter.`, 'info');
-          updateRoleActionState();
-          return;
-        }
-
-        try {
-          removeSetterButton.disabled = true;
-          if (grantSetterButton) {
-            grantSetterButton.disabled = true;
+        } finally {
+          setRoleControlsEnabled(true);
+          if (roleEmailInput) {
+            roleEmailInput.focus();
           }
-          setRoleStatus(`Removing setter role from ${entry.email}…`, 'info');
-          const roleRef = doc(db, 'roles', selectedId);
-          const email = entry.email || '';
-          await setDoc(
-            roleRef,
-            {
-              role: 'default',
-              updatedAt: serverTimestamp(),
-              email,
-              emailLower: email.toLowerCase(),
-            },
-            { merge: true },
-          );
-          roleSearchResults.set(selectedId, { ...entry, role: 'default' });
-          updateRoleOptionLabel(selectedId);
-          updateRoleActionState();
-          setRoleStatus(`Setter role removed from ${entry.email}.`, 'success');
-        } catch (error) {
-          console.error('Failed to remove setter role:', error);
-          setRoleStatus('Unable to remove setter role. Please try again.', 'error');
-          updateRoleActionState();
         }
       });
     }
 
-    resetRoleManagementUI();
+    resetRoleManagementUI('Enter the email of the user you want to promote.');
 
     function normalizeDateValue(value) {
       if (!value) {
@@ -1462,176 +1396,6 @@
       roleStatusMessage.textContent = '';
       roleStatusMessage.classList.add('hidden');
       delete roleStatusMessage.dataset.variant;
-    }
-
-    function clearRoleResults(placeholder = 'Search for a user to begin.') {
-      roleSearchResults.clear();
-      if (roleResultsList) {
-        roleResultsList.innerHTML = '';
-        const option = document.createElement('option');
-        option.value = '';
-        option.textContent = placeholder;
-        option.disabled = true;
-        option.selected = true;
-        roleResultsList.append(option);
-      }
-      updateRoleActionState();
-    }
-
-    function resetRoleManagementUI(message = '') {
-      if (roleSearchInput) {
-        roleSearchInput.value = '';
-      }
-      if (message) {
-        setRoleStatus(message, 'info');
-      } else {
-        clearRoleStatus();
-      }
-      clearRoleResults(message || 'Search for a user to begin.');
-    }
-
-    function updateRoleOptionLabel(userId) {
-      if (!roleResultsList || !roleSearchResults.has(userId)) {
-        return;
-      }
-      const record = roleSearchResults.get(userId);
-      const email = record?.email || 'Unknown email';
-      const role = record?.role || 'unknown';
-      const suffix = currentUserId && userId === currentUserId ? ' (you)' : '';
-      const label = `${email} – ${role}${suffix}`;
-      for (const option of roleResultsList.options) {
-        if (option.value === userId) {
-          option.textContent = label;
-          break;
-        }
-      }
-    }
-
-    function updateRoleActionState() {
-      const hasGrantButton = Boolean(grantSetterButton);
-      const hasRemoveButton = Boolean(removeSetterButton);
-      if (!hasGrantButton && !hasRemoveButton) {
-        return;
-      }
-
-      const selectedId = roleResultsList?.value || '';
-      let disableGrant = true;
-      let disableRemove = true;
-
-      if (selectedId && roleSearchResults.has(selectedId)) {
-        const record = roleSearchResults.get(selectedId);
-        const isSelf = currentUserId && selectedId === currentUserId;
-        disableGrant = record?.role === 'setter' || Boolean(isSelf);
-        disableRemove = record?.role !== 'setter' || Boolean(isSelf);
-      }
-
-      if (hasGrantButton) {
-        grantSetterButton.disabled = disableGrant;
-      }
-      if (hasRemoveButton) {
-        removeSetterButton.disabled = disableRemove;
-      }
-    }
-
-    async function performRoleLookup() {
-      if (!roleSearchInput) {
-        return;
-      }
-
-      const rawTerm = roleSearchInput.value.trim();
-      const normalized = rawTerm.toLowerCase();
-
-      if (!normalized) {
-        clearRoleResults('Enter an email to search');
-        setRoleStatus('Enter an email address to search.', 'info');
-        return;
-      }
-
-      setRoleStatus('Searching for users…', 'info');
-
-      if (roleResultsList) {
-        roleResultsList.innerHTML = '';
-        const loadingOption = document.createElement('option');
-        loadingOption.value = '';
-        loadingOption.textContent = 'Searching…';
-        loadingOption.disabled = true;
-        loadingOption.selected = true;
-        roleResultsList.append(loadingOption);
-      }
-      updateRoleActionState();
-
-      try {
-        const rolesQuery = query(
-          collection(db, 'roles'),
-          orderBy('email'),
-          startAt(rawTerm),
-          endAt(`${rawTerm}\uf8ff`),
-          limit(MAX_ROLE_RESULTS),
-        );
-
-        const snapshot = await getDocs(rolesQuery);
-        roleSearchResults.clear();
-
-        if (!roleResultsList) {
-          return;
-        }
-
-        roleResultsList.innerHTML = '';
-
-        const matches = [];
-
-        snapshot.forEach((docSnap) => {
-          const data = docSnap.data() || {};
-          const email = typeof data.email === 'string' ? data.email.trim() : '';
-          const role = typeof data.role === 'string' ? data.role.trim() : 'default';
-          if (!email) {
-            return;
-          }
-
-          if (!email.toLowerCase().includes(normalized)) {
-            return;
-          }
-
-          matches.push({ id: docSnap.id, email, role });
-        });
-
-        if (matches.length === 0) {
-          clearRoleResults('No users found');
-          setRoleStatus('No matching users found.', 'info');
-          return;
-        }
-
-        for (const match of matches) {
-          const { id, email, role } = match;
-          roleSearchResults.set(id, { email, role });
-          const option = document.createElement('option');
-          option.value = id;
-          option.textContent = `${email} – ${role}${currentUserId && id === currentUserId ? ' (you)' : ''}`;
-          roleResultsList.append(option);
-        }
-
-        roleResultsList.selectedIndex = 0;
-        updateRoleActionState();
-
-        const firstId = roleResultsList.value;
-        if (firstId && roleSearchResults.has(firstId)) {
-          const entry = roleSearchResults.get(firstId);
-          const isSelf = currentUserId && firstId === currentUserId;
-          if (isSelf) {
-            setRoleStatus('You cannot change your own role.', 'info');
-          } else if (entry.role === 'setter') {
-            setRoleStatus(`Ready to remove setter role from ${entry.email}.`, 'info');
-          } else {
-            setRoleStatus(`Ready to grant setter role to ${entry.email}.`, 'info');
-          }
-        } else {
-          setRoleStatus('Select a user to manage setter access.', 'info');
-        }
-      } catch (error) {
-        console.error('Failed to lookup user roles:', error);
-        clearRoleResults('Unable to load users');
-        setRoleStatus('Failed to search for users. Please try again.', 'error');
-      }
     }
 
     function markUnsavedChange() {
@@ -2328,6 +2092,7 @@
       routeSelector.disabled = true;
       deleteButton.disabled = true;
       clearStatus();
+      setRoleControlsEnabled(false);
       resetRoleManagementUI('Setter access required to manage roles.');
     }
 
@@ -2335,13 +2100,8 @@
       unauthorizedNotice.classList.add('hidden');
       appContent.classList.remove('hidden');
       routeSelector.disabled = false;
-      for (const userId of roleSearchResults.keys()) {
-        updateRoleOptionLabel(userId);
-      }
-      updateRoleActionState();
-      if (!roleResultsList || !roleResultsList.value || !roleSearchResults.has(roleResultsList.value)) {
-        clearRoleStatus();
-      }
+      setRoleControlsEnabled(true);
+      clearRoleStatus();
     }
 
     onAuthStateChanged(auth, async (user) => {
@@ -2386,6 +2146,7 @@
         authForm.reset();
         prepareNewRoute();
         clearStatus();
+        setRoleControlsEnabled(false);
         resetRoleManagementUI();
         setAuthMode('login');
       }


### PR DESCRIPTION
## Summary
- replace the role lookup interface with a simple email input for granting setter access
- update the grant flow to create or update role documents based on the supplied email address
- tighten role management UI state handling so controls stay disabled until a setter is authorized

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e64c43ca44832797e6dc4c80f3ac69