### PR TITLE
Align grade note text color with tooltip theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -406,7 +406,7 @@
 
       .grade-note {
         font-size: 0.75rem;
-        color: rgba(255, 255, 255, 0.7);
+        color: var(--tooltip-foreground, rgba(255, 255, 255, 0.7));
       }
 
       .ascend-status {


### PR DESCRIPTION
## Summary
- update the grade note text color to use the tooltip foreground variable for consistent styling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e66751cec48327bc0e1136347bd14c