### PR TITLE
Style ascended status indicator with hollow check

### DIFF
--- a/index.html
+++ b/index.html
@@ -412,24 +412,38 @@
       .ascend-status {
         display: inline-flex;
         align-items: center;
-        gap: 0.35rem;
         font-weight: 600;
         color: var(--tooltip-foreground, #fff);
+        position: relative;
+        padding-left: 1.55rem;
       }
 
       .ascend-status::before {
-        content: '✔';
-        font-size: 0.9rem;
-        color: inherit;
+        content: '';
+        position: absolute;
+        left: 0;
+        top: 50%;
+        width: 1rem;
+        height: 1rem;
+        border: 2px solid currentColor;
+        border-radius: 50%;
+        transform: translateY(-50%);
+      }
+
+      .ascend-status:not(.not-ascended)::after {
+        content: '';
+        position: absolute;
+        left: 0.22rem;
+        top: 50%;
+        width: 0.45rem;
+        height: 0.75rem;
+        border-right: 0.18rem solid currentColor;
+        border-bottom: 0.18rem solid currentColor;
+        transform: translate(40%, -55%) rotate(45deg);
       }
 
       .ascend-status.not-ascended {
         opacity: 0.75;
-      }
-
-      .ascend-status.not-ascended::before {
-        content: '○';
-        font-size: 0.9rem;
       }
     </style>
   </head>


### PR DESCRIPTION
## Summary
- restyled the ascended status indicator to use a hollow circle shared with the non-ascended state
- added an overhanging check mark to the ascended indicator to visually distinguish it from the non-ascended variant

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e681847ec8832790319776eddea122